### PR TITLE
Use secure WebSocket connection if HTTPS

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -611,7 +611,7 @@ function setState(newState) {
 
 // ── WebSocket ──
 function connect() {
-  ws = new WebSocket(`ws://${location.host}/ws`);
+  ws = new WebSocket(`${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`);
   ws.onopen = () => {
     setStatus('connected', 'Connected');
     if (state !== 'loading') setState('listening');


### PR DESCRIPTION
When serving the app via secure connection (ie: tailscale serve) the app goes into hybrid mode preventing access. 
This one-line PR allows matching the websocket security to the page security.