### PR TITLE
Pin Python to 3.12 to prevent install failures on 3.13+

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -2,7 +2,7 @@
 name = "parlor"
 version = "0.1.0"
 description = "On-device, real-time multimodal AI — have natural voice + vision conversations, fully local and private"
-requires-python = ">=3.12"
+requires-python = ">=3.12,<3.13"
 dependencies = [
     "fastapi>=0.135.3",
     "kokoro-onnx>=0.5.0; sys_platform == 'linux'",


### PR DESCRIPTION
## Summary
- Pins `requires-python` to `>=3.12,<3.13` in `pyproject.toml`
- Several upstream dependencies lack Python 3.13/3.14 support:
  - `misaki` 0.9.4 declares `requires-python: <3.13`
  - `curated-tokenizers` (via `misaki[en]` → `spacy-curated-transformers`) has no cp313/cp314 wheels and fails to compile from source
  - `kokoro-onnx` explicitly excludes 3.14 (`requires-python: <3.14`)
  - `spacy` 3.8.14 is missing cp314 wheels (packaging regression)

## Test plan
- [ ] Verify `uv sync` works on Python 3.12
- [ ] Verify `uv sync` correctly rejects Python 3.13+

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)