### PR TITLE
feat: add MiniMax TTS provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,10 @@
 
 # Server port (default: 8000)
 # PORT=8000
+
+# MiniMax cloud TTS (optional — uses local Kokoro TTS if not set)
+# When set, MiniMax TTS API is used instead of local Kokoro models.
+# Get your API key at https://platform.minimax.io
+# MINIMAX_API_KEY=your_api_key_here
+# MINIMAX_BASE_URL=https://api.minimax.io  # default; use https://api.minimaxi.com for China region
+# MINIMAX_TTS_MODEL=speech-2.8-hd  # or speech-2.8-turbo for faster synthesis

--- a/src/tests/test_minimax_tts.py
+++ b/src/tests/test_minimax_tts.py
@@ -1,0 +1,211 @@
+"""Unit tests for MiniMaxTTSBackend."""
+
+import json
+import os
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# Add src to path so we can import tts module
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from tts import MiniMaxTTSBackend
+
+
+class TestMiniMaxTTSBackend:
+    def test_init_with_explicit_key(self):
+        backend = MiniMaxTTSBackend(api_key="test-key")
+        assert backend._api_key == "test-key"
+        assert backend._base_url == "https://api.minimax.io"
+        assert backend.sample_rate == 32000
+
+    def test_init_from_env(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "env-key")
+        backend = MiniMaxTTSBackend()
+        assert backend._api_key == "env-key"
+
+    def test_init_custom_base_url(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_BASE_URL", "https://api.minimaxi.com")
+        backend = MiniMaxTTSBackend(api_key="test-key")
+        assert backend._base_url == "https://api.minimaxi.com"
+
+    def test_init_strips_trailing_slash(self):
+        backend = MiniMaxTTSBackend(api_key="test-key", base_url="https://api.minimax.io/")
+        assert backend._base_url == "https://api.minimax.io"
+
+    def test_init_requires_api_key(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="MINIMAX_API_KEY"):
+            MiniMaxTTSBackend()
+
+    def test_generate_returns_float32_array(self):
+        # Build a fake 100ms of silence at 32000 Hz (32000 * 0.1 = 3200 samples)
+        pcm_int16 = np.zeros(3200, dtype=np.int16)
+        audio_hex = pcm_int16.tobytes().hex()
+
+        fake_response = json.dumps({
+            "data": {"audio": audio_hex},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = fake_response
+
+        backend = MiniMaxTTSBackend(api_key="test-key")
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = backend.generate("Hello world")
+
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float32
+        assert len(result) == 3200
+        assert result.max() <= 1.0
+        assert result.min() >= -1.0
+
+    def test_generate_normalizes_audio(self):
+        # Max int16 value should become ~1.0 in float32
+        pcm_int16 = np.array([32767, -32768, 0, 16383], dtype=np.int16)
+        audio_hex = pcm_int16.tobytes().hex()
+
+        fake_response = json.dumps({
+            "data": {"audio": audio_hex},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = fake_response
+
+        backend = MiniMaxTTSBackend(api_key="test-key")
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = backend.generate("Hello")
+
+        assert result[0] == pytest.approx(32767 / 32767.0, abs=1e-5)
+        assert result[1] == pytest.approx(-32768 / 32767.0, abs=1e-5)
+        assert result[2] == pytest.approx(0.0, abs=1e-5)
+
+    def test_generate_raises_on_api_error(self):
+        fake_response = json.dumps({
+            "data": {},
+            "base_resp": {"status_code": 1001, "status_msg": "invalid api key"},
+        }).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = fake_response
+
+        backend = MiniMaxTTSBackend(api_key="bad-key")
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            with pytest.raises(RuntimeError, match="1001"):
+                backend.generate("Hello")
+
+    def test_generate_uses_correct_url(self):
+        pcm_int16 = np.zeros(100, dtype=np.int16)
+        fake_response = json.dumps({
+            "data": {"audio": pcm_int16.tobytes().hex()},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = fake_response
+
+        backend = MiniMaxTTSBackend(api_key="test-key")
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+            backend.generate("Hello")
+
+        call_args = mock_urlopen.call_args[0][0]
+        assert call_args.full_url == "https://api.minimax.io/v1/t2a_v2"
+
+    def test_generate_request_payload(self):
+        pcm_int16 = np.zeros(100, dtype=np.int16)
+        fake_response = json.dumps({
+            "data": {"audio": pcm_int16.tobytes().hex()},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = fake_response
+
+        backend = MiniMaxTTSBackend(api_key="test-key")
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+            backend.generate("Hello world", voice="English_Persuasive_Man", speed=1.2)
+
+        call_args = mock_urlopen.call_args[0][0]
+        payload = json.loads(call_args.data)
+
+        assert payload["text"] == "Hello world"
+        assert payload["stream"] is False
+        assert payload["voice_setting"]["voice_id"] == "English_Persuasive_Man"
+        assert payload["voice_setting"]["speed"] == 1.2
+        assert payload["audio_setting"]["format"] == "pcm"
+        assert payload["audio_setting"]["sample_rate"] == 32000
+        assert payload["audio_setting"]["channel"] == 1
+
+    def test_generate_uses_bearer_auth(self):
+        pcm_int16 = np.zeros(100, dtype=np.int16)
+        fake_response = json.dumps({
+            "data": {"audio": pcm_int16.tobytes().hex()},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = fake_response
+
+        backend = MiniMaxTTSBackend(api_key="my-secret-key")
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+            backend.generate("Hello")
+
+        call_args = mock_urlopen.call_args[0][0]
+        assert call_args.get_header("Authorization") == "Bearer my-secret-key"
+
+    def test_default_model_is_speech_28_hd(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_TTS_MODEL", raising=False)
+        pcm_int16 = np.zeros(100, dtype=np.int16)
+        fake_response = json.dumps({
+            "data": {"audio": pcm_int16.tobytes().hex()},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = fake_response
+
+        backend = MiniMaxTTSBackend(api_key="test-key")
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+            backend.generate("Hello")
+
+        call_args = mock_urlopen.call_args[0][0]
+        payload = json.loads(call_args.data)
+        assert payload["model"] == "speech-2.8-hd"
+
+
+class TestLoadFunctionWithMiniMax:
+    def test_load_uses_minimax_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+        from tts import load
+        backend = load()
+        assert isinstance(backend, MiniMaxTTSBackend)
+
+    def test_load_skips_minimax_when_no_key(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.setenv("KOKORO_ONNX", "1")  # force ONNX path
+
+        # Mock ONNXBackend init to avoid downloading models
+        with patch("tts.ONNXBackend.__init__", return_value=None):
+            with patch("tts.ONNXBackend.sample_rate", new=24000, create=True):
+                from tts import load
+                backend = load()
+                assert not isinstance(backend, MiniMaxTTSBackend)

--- a/src/tts.py
+++ b/src/tts.py
@@ -1,8 +1,14 @@
-"""Platform-aware Kokoro TTS: mlx-audio on Apple Silicon, kokoro-onnx elsewhere."""
+"""Platform-aware Kokoro TTS: mlx-audio on Apple Silicon, kokoro-onnx elsewhere.
 
+Set MINIMAX_API_KEY to use MiniMax cloud TTS instead of local Kokoro models.
+"""
+
+import json
 import os
 import platform
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 import numpy as np
@@ -19,6 +25,85 @@ class TTSBackend:
 
     def generate(self, text: str, voice: str = "af_heart", speed: float = 1.1) -> np.ndarray:
         raise NotImplementedError
+
+
+class MiniMaxTTSBackend(TTSBackend):
+    """MiniMax cloud TTS backend (https://api.minimax.io/v1/t2a_v2).
+
+    Activated when MINIMAX_API_KEY is set. Uses PCM audio format to avoid
+    any extra decoding dependencies — the hex-encoded PCM bytes are converted
+    directly to a float32 numpy array.
+
+    Supported voices: English_Graceful_Lady, English_Insightful_Speaker,
+    English_radiant_girl, English_Persuasive_Man, English_Lucky_Robot,
+    English_expressive_narrator.
+
+    Supported models: speech-2.8-hd (default), speech-2.8-turbo.
+    """
+
+    VOICES = [
+        "English_Graceful_Lady",
+        "English_Insightful_Speaker",
+        "English_radiant_girl",
+        "English_Persuasive_Man",
+        "English_Lucky_Robot",
+        "English_expressive_narrator",
+    ]
+
+    sample_rate: int = 32000
+
+    def __init__(self, api_key: str | None = None, base_url: str | None = None):
+        self._api_key = api_key or os.environ.get("MINIMAX_API_KEY", "")
+        if not self._api_key:
+            raise ValueError("MINIMAX_API_KEY is required for MiniMaxTTSBackend")
+        self._base_url = (
+            base_url or os.environ.get("MINIMAX_BASE_URL", "https://api.minimax.io")
+        ).rstrip("/")
+
+    def generate(
+        self, text: str, voice: str = "English_Graceful_Lady", speed: float = 1.0
+    ) -> np.ndarray:
+        """Synthesize speech and return float32 PCM audio array."""
+        url = f"{self._base_url}/v1/t2a_v2"
+        model = os.environ.get("MINIMAX_TTS_MODEL", "speech-2.8-hd")
+        payload = json.dumps(
+            {
+                "model": model,
+                "text": text,
+                "stream": False,
+                "voice_setting": {
+                    "voice_id": voice,
+                    "speed": speed,
+                    "vol": 1,
+                    "pitch": 0,
+                },
+                "audio_setting": {
+                    "sample_rate": self.sample_rate,
+                    "format": "pcm",
+                    "channel": 1,
+                },
+            }
+        ).encode()
+
+        req = urllib.request.Request(
+            url,
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self._api_key}",
+            },
+        )
+        with urllib.request.urlopen(req) as resp:
+            result = json.loads(resp.read())
+
+        status = result.get("base_resp", {}).get("status_code", -1)
+        if status != 0:
+            msg = result.get("base_resp", {}).get("status_msg", "unknown error")
+            raise RuntimeError(f"MiniMax TTS API error {status}: {msg}")
+
+        audio_hex = result["data"]["audio"]
+        audio_bytes = bytes.fromhex(audio_hex)
+        return np.frombuffer(audio_bytes, dtype=np.int16).astype(np.float32) / 32767.0
 
 
 class MLXBackend(TTSBackend):
@@ -56,7 +141,18 @@ class ONNXBackend(TTSBackend):
 
 
 def load() -> TTSBackend:
-    """Load the best available TTS backend for this platform."""
+    """Load the best available TTS backend for this platform.
+
+    Priority:
+    1. MiniMax cloud TTS — if MINIMAX_API_KEY is set.
+    2. mlx-audio (Apple Silicon GPU) — on macOS arm64 unless KOKORO_ONNX is set.
+    3. kokoro-onnx (CPU) — fallback for all other platforms.
+    """
+    if os.environ.get("MINIMAX_API_KEY"):
+        backend = MiniMaxTTSBackend()
+        print(f"TTS: MiniMax cloud (sample_rate={backend.sample_rate})")
+        return backend
+
     if _is_apple_silicon() and not os.environ.get("KOKORO_ONNX"):
         try:
             backend = MLXBackend()


### PR DESCRIPTION
## Summary

This PR adds [MiniMax](https://platform.minimax.io) as an optional cloud TTS provider, offering an alternative to the local Kokoro models.

### Changes

- **`src/tts.py`**: New `MiniMaxTTSBackend` class that calls the MiniMax TTS API (`/v1/t2a_v2`) and returns a float32 PCM numpy array — no extra dependencies required (uses stdlib `urllib` and the already-present `numpy`). Uses PCM audio format for zero-overhead decoding.
- **`src/tts.py`**: Updated `load()` to select MiniMax first when `MINIMAX_API_KEY` is set, falling back to local Kokoro backends as before.
- **`.env.example`**: Documents the three new environment variables.
- **`src/tests/test_minimax_tts.py`**: 14 unit tests covering initialization, request payload, audio normalization, error handling, and backend selection.

### Configuration

Set `MINIMAX_API_KEY` in your environment (or `.env`) to activate:

```
MINIMAX_API_KEY=your_api_key_here
MINIMAX_BASE_URL=https://api.minimax.io       # default; use https://api.minimaxi.com for China
MINIMAX_TTS_MODEL=speech-2.8-hd               # or speech-2.8-turbo for faster synthesis
```

Without the key, behavior is unchanged — local Kokoro backends are used as before.

### Why MiniMax?

MiniMax offers high-quality, low-latency TTS via a simple REST API. It's a useful option for:
- Platforms where local model dependencies (mlx-audio, kokoro-onnx) are unavailable
- Users who prefer cloud TTS without managing local model weights

### API references

- TTS: https://platform.minimax.io/docs/api-reference/speech-t2a-http

### Testing

All 14 unit tests pass:
```
14 passed in 0.60s
```

Integration tested against the live MiniMax API — successfully generates ~4s of audio for a typical sentence.