### PR TITLE
Fix resource leak: add proper cleanup for engine lifecycle

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -56,13 +56,22 @@ def load_models():
     engine.__enter__()
     print("Engine loaded.")
 
-    tts_backend = tts.load()
+    try:
+        tts_backend = tts.load()
+    except Exception:
+        # Clean up engine if TTS loading fails
+        engine.__exit__(None, None, None)
+        engine = None
+        raise
 
 
 @asynccontextmanager
 async def lifespan(app):
     await asyncio.get_event_loop().run_in_executor(None, load_models)
     yield
+    # Clean up engine resources on shutdown
+    if engine:
+        engine.__exit__(None, None, None)
 
 
 app = FastAPI(lifespan=lifespan)


### PR DESCRIPTION
## Summary
This PR fixes a resource leak where the Gemma 4 E2B engine's `__enter__()` was called during initialization but the corresponding `__exit__()` was never called, leading to GPU resources not being properly released.

## Root Cause

In `src/server.py`, the `load_models()` function:
1. Creates the engine and calls `engine.__enter__()` to acquire resources
2. Loads the TTS backend

However, the engine's `__exit__()` was never called in two scenarios:
1. When the application shuts down
2. If TTS loading fails after engine initialization

## Changes

1. **Added cleanup in lifespan shutdown handler**: Calls `engine.__exit__()` when the FastAPI application shuts down, ensuring GPU resources are released gracefully.

2. **Added cleanup during initialization**: If TTS loading fails after the engine has been initialized, the engine is properly cleaned up before propagating the exception.

## Impact

- Prevents GPU memory leaks on application shutdown
- Ensures proper cleanup if TTS backend initialization fails
- Makes the resource management more robust

🤖 Generated with [Claude Code](https://claude.com/claude-code)