### PR TITLE
Delete TURN_MODE: measure the three turn modes, keep only smart-turn

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -19,11 +19,12 @@ still needs human testing. Delete this file before merging.
    (official Google QAT q4_0 GGUF + mmproj). The server owns conversation
    history; prefix caching makes re-sending it cheap. Real barge-in abort.
    litert-lm can be restored by reverting two commits (`2284193`, `37caaaf`).
-5. **Turn detection** — after live testing showed Gemma E2B cannot reliably
-   judge FINISHED/WAIT (in inline-marker or separate-request form), judgment
-   moved to pipecat's smart-turn-v3 audio classifier (~25ms CPU). The LLM
-   prompt now carries no format instructions at all. `TURN_MODE=marker` and
-   `two_phase` remain for comparison.
+5. **Turn detection** — judgment belongs to pipecat's smart-turn-v3.2 audio
+   classifier (~20ms CPU), and the LLM prompt carries no format instructions
+   at all. The inline-marker and separate-request variants were measured
+   (`benchmarks/turnbench.py`) at chance accuracy on E2B, E4B *and* 12B, so
+   `TURN_MODE` is gone and only the classifier path remains. The benchmark
+   still reproduces both variants against any future model.
 6. **Live-session fixes** — history poisoning by invalid audio, echo
    parroting (AEC reference path + sustained-speech barge-in), capture leak.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Models are downloaded automatically on first run (~4 GB for Gemma 4 E2B QAT + it
 | `LLAMA_CTX`        | `16384`                        | llama.cpp context size. The server drops the oldest exchanges shortly before it fills |
 | `LLAMA_PORT`       | `8081`                         | Port for the spawned llama-server              |
 | `LLAMA_SERVER_URL` | (spawn our own)                | Use an already-running llama-server instead    |
-| `TURN_MODE`        | `marker`                       | `two_phase` splits each turn into a decision request + a clean response request |
 
 ## Performance (Apple M3 Pro)
 

--- a/src/benchmarks/turnbench.py
+++ b/src/benchmarks/turnbench.py
@@ -38,6 +38,7 @@ import contextlib
 import io
 import json
 import os
+import re
 import sys
 import time
 import urllib.parse
@@ -67,6 +68,59 @@ MODELS = {
 }
 
 BENCH_PORT = "8099"  # not 8081, so a dev server can keep running alongside
+
+# The two LLM-judged variants server.py used to ship as TURN_MODE=marker and
+# TURN_MODE=two_phase. They live here now: they lost badly enough to be worth
+# deleting from the server, but re-running them against the next Gemma is a
+# one-line change, so the prompts stay reproducible rather than lost to git.
+MARKER_SYSTEM_PROMPT = (
+    "You are a friendly, conversational AI assistant. The user talks to you "
+    "through a microphone and may show you their camera. Your reply is spoken "
+    "aloud, so write plain conversational text: 1-4 short sentences, no formatting.\n"
+    "\n"
+    "Your reply MUST start with exactly one of these words on its own line, "
+    "judging the user's speech:\n"
+    "- FINISHED — the user completed their thought. Continue with your spoken "
+    "response on the next line.\n"
+    "- WAIT — the user has not finished: they were cut off mid-sentence or are "
+    "pausing to think. Say nothing else and let them continue.\n"
+    "Also reply WAIT if the audio is just an echo of your own previous reply "
+    "(the microphone picking up your voice) or is silence or noise.\n"
+    "\n"
+    "If the user sent audio, end your reply with a new line:\n"
+    "###TRANSCRIPT: the exact words the user said\n"
+    "\n"
+    "Examples:\n"
+    'User audio: "What\'s your favorite color?"\n'
+    "You: FINISHED\n"
+    "I really like deep blue. What about you?\n"
+    "###TRANSCRIPT: What's your favorite color?\n"
+    "\n"
+    'User audio: "So the thing I wanted to say is"\n'
+    "You: WAIT\n"
+    "\n"
+    'User audio: "Hmm, let me think about that for a second."\n'
+    "You: WAIT\n"
+)
+
+MARKER_INSTRUCTION = (
+    "The user just spoke to you. Start with FINISHED or WAIT, then respond to "
+    "what they said. End with the ###TRANSCRIPT line."
+)
+
+DECISION_PROMPT = (
+    "The user just spoke. Judge ONLY whether they finished their thought — "
+    "do not answer them yet. Examples:\n"
+    '"What is your favorite food?" -> FINISHED\n'
+    '"I moved here last year and I want to know how I can make more friends." -> FINISHED\n'
+    '"So the thing I wanted to ask is" -> WAIT\n'
+    '"Hmm, let me think about that." -> WAIT\n'
+    "Reply with exactly one word: FINISHED or WAIT."
+)
+
+# Close variants ("FINISH", trailing colon, markdown wrap) count too — they
+# never open a real response in uppercase.
+MARKER_RE = re.compile(r"[\s*_]*(FINISHED|FINISH|WAITING|WAIT)\b[:.]?[\s*_]*")
 
 
 # ── clip fetching ─────────────────────────────────────────────────────────
@@ -158,33 +212,32 @@ def judge_smart(detector, audio: np.ndarray, _b64: str) -> tuple[bool, float]:
 
 
 def judge_marker(server, _audio, b64: str) -> tuple[bool, float]:
-    """Production `marker` path, stopped after the marker token: the reply
-    text costs the same whichever way the marker went, so decision latency
-    is what turn-taking actually feels."""
+    """Stopped after the marker token: the reply text costs the same
+    whichever way the marker went, so decision latency is what turn-taking
+    actually feels."""
     messages = [
-        {"role": "system", "content": server.SYSTEM_PROMPT},
+        {"role": "system", "content": MARKER_SYSTEM_PROMPT},
         {"role": "user", "content": [
-            server.audio_part(b64),
-            server.text_part(server.marker_instruction({}, False, True))]},
+            server.audio_part(b64), server.text_part(MARKER_INSTRUCTION)]},
     ]
-    return _marker_verdict(server, server.chat_blocking(messages, max_tokens=8))
+    return _marker_verdict(server.chat_blocking(messages, max_tokens=8))
 
 
 def judge_two_phase(server, _audio, b64: str) -> tuple[bool, float]:
     messages = [
-        {"role": "system", "content": server.SYSTEM_PROMPT_TWO_PHASE},
+        {"role": "system", "content": server.SYSTEM_PROMPT},
         {"role": "user", "content": [
-            server.audio_part(b64), server.text_part(server.DECISION_PROMPT)]},
+            server.audio_part(b64), server.text_part(DECISION_PROMPT)]},
     ]
-    return _marker_verdict(server, server.chat_blocking(messages, max_tokens=6))
+    return _marker_verdict(server.chat_blocking(messages, max_tokens=6))
 
 
-def _marker_verdict(server, text: str) -> tuple[bool, float]:
-    """A missing or garbled marker counts as 'complete' — that is what
-    StreamParser falls back to in production."""
-    match = server.MARKER_RE.match(text.strip())
-    kind = server.MARKER_KINDS.get(match.group(1)) if match else None
-    return kind != "incomplete", 1.0 if kind is None else float(kind == "complete")
+def _marker_verdict(text: str) -> tuple[bool, float]:
+    """A missing or garbled marker counts as 'complete' — the fallback the
+    old StreamParser used when no marker arrived."""
+    match = MARKER_RE.match(text.strip())
+    complete = not match or match.group(1).startswith("FINISH")
+    return complete, float(complete)
 
 
 JUDGES = {"smart": judge_smart, "marker": judge_marker, "two_phase": judge_two_phase}

--- a/src/benchmarks/turnbench.py
+++ b/src/benchmarks/turnbench.py
@@ -1,0 +1,337 @@
+"""Turn-detection benchmark — which TURN_MODE judges "did the user finish?"
+best, and how fast.
+
+Scores the three modes in server.py against labelled human speech from
+pipecat's smart-turn v3.2 test set (`endpoint_bool`: did the turn end?):
+
+    smart      — the smart-turn-v3.2 ONNX classifier (acoustic, no LLM)
+    marker     — Gemma starts its reply with FINISHED / WAIT
+    two_phase  — a separate one-word Gemma request, then the response
+
+Only real human recordings are used (`synthetic=false`). TTS-synthesized
+clips read as finished no matter what the words are, which flatters the
+LLM modes and unfairly punishes the acoustic one — the same effect that
+makes the `thinking_suppressed` check in bench.py fail by construction.
+Pass --synthetic to include them anyway; outside English they are often
+all a language has (every Indonesian clip in the set is synthetic).
+
+    # cache clips once, N per class per language (needs network)
+    uv run python benchmarks/turnbench.py --fetch 100
+
+    # the acoustic classifier — no LLM, so run it once for all models
+    uv run python benchmarks/turnbench.py --modes smart \
+        --out benchmarks/results/turn-smart.json
+
+    # the LLM modes; each spawns its own llama-server on port 8099
+    uv run python benchmarks/turnbench.py --model e4b --modes marker,two_phase \
+        --out benchmarks/results/turn-e4b.json
+
+Caveat: this is smart-turn's own test split, so it is in-domain for the
+`smart` mode and its score here is optimistic. LiveKit's eot-bench
+(Apache-2.0, 14 languages, real human-to-agent turns) is the independent
+cross-check, and scores smart-turn v3.2 far more harshly.
+"""
+
+import argparse
+import base64
+import contextlib
+import io
+import json
+import os
+import sys
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import fixtures
+
+DATASET = "pipecat-ai/smart-turn-data-v3.2-test"
+FILTER_URL = "https://datasets-server.huggingface.co/filter"
+CLIPS_DIR = Path(__file__).parent / "fixtures" / "turn"
+MANIFEST = CLIPS_DIR / "manifest.json"
+
+# GGUF repo, weights, mmproj — all three are Google's official QAT q4_0.
+MODELS = {
+    "e2b": ("google/gemma-4-E2B-it-qat-q4_0-gguf",
+            "gemma-4-E2B_q4_0-it.gguf", "gemma-4-E2B-it-mmproj.gguf"),
+    "e4b": ("google/gemma-4-E4B-it-qat-q4_0-gguf",
+            "gemma-4-E4B_q4_0-it.gguf", "gemma-4-E4B-it-mmproj.gguf"),
+    "12b": ("google/gemma-4-12B-it-qat-q4_0-gguf",
+            "gemma-4-12b-it-qat-q4_0.gguf", "mmproj-gemma-4-12b-it-qat-q4_0.gguf"),
+}
+
+BENCH_PORT = "8099"  # not 8081, so a dev server can keep running alongside
+
+
+# ── clip fetching ─────────────────────────────────────────────────────────
+
+def _query(lang: str, complete: bool, synthetic: bool, offset: int, length: int) -> dict:
+    where = f"\"language\"='{lang}' AND \"endpoint_bool\"={'true' if complete else 'false'}"
+    if not synthetic:
+        where += ' AND "synthetic"=false'
+    params = {
+        "dataset": DATASET, "config": "default", "split": "train", "where": where,
+        "orderby": '"id"',  # deterministic paging and a stable sample
+        "offset": offset, "length": length,
+    }
+    url = FILTER_URL + "?" + urllib.parse.urlencode(params)
+    problem = "no attempt made"
+    for attempt in range(10):
+        try:
+            with urllib.request.urlopen(url, timeout=60) as r:
+                data = json.loads(r.read())
+            if "error" not in data:
+                return data
+            problem = data["error"]  # a cold index builds server-side
+        except urllib.error.HTTPError as e:
+            problem = f"HTTP {e.code}"
+        print(f"  datasets-server: {problem} (retry {attempt + 1})")
+        time.sleep(15)
+    raise RuntimeError(f"datasets-server never answered: {problem}")
+
+
+def fetch_clips(langs: list[str], per_class: int, synthetic: bool) -> None:
+    """Cache a balanced complete/incomplete sample as 16kHz mono WAVs."""
+    CLIPS_DIR.mkdir(parents=True, exist_ok=True)
+    manifest = []
+    for lang in langs:
+        for complete in (True, False):
+            got = 0
+            while got < per_class:
+                page = _query(lang, complete, synthetic, got, min(100, per_class - got))
+                rows = page["rows"]
+                if not rows:
+                    print(f"  {lang} complete={complete}: only {got} rows exist")
+                    break
+                print(f"  {lang} complete={complete}: {got + len(rows)}/{per_class} "
+                      f"(of {page['num_rows_total']} available)")
+                for entry in rows:
+                    row = entry["row"]
+                    path = CLIPS_DIR / f"{row['id']}.wav"
+                    if not path.exists():
+                        with urllib.request.urlopen(row["audio"][0]["src"], timeout=60) as r:
+                            pcm, sr = sf.read(io.BytesIO(r.read()), dtype="float32")
+                        if pcm.ndim > 1:
+                            pcm = pcm.mean(axis=1)
+                        fixtures._write_wav(
+                            path, fixtures._resample_linear(pcm, sr, fixtures.TARGET_SR),
+                            fixtures.TARGET_SR)
+                    manifest.append({"id": row["id"], "lang": lang,
+                                     "complete": complete, "source": row["dataset"],
+                                     "synthetic": row["synthetic"]})
+                got += len(rows)
+    # Merge, so real-speech and synthetic-language fetches can be combined.
+    merged = {c["id"]: c for c in
+              (json.loads(MANIFEST.read_text()) if MANIFEST.exists() else [])}
+    merged.update({c["id"]: c for c in manifest})
+    MANIFEST.write_text(json.dumps(list(merged.values()), indent=2))
+    print(f"Cached {len(manifest)} clips ({len(merged)} total) in {CLIPS_DIR}")
+
+
+def load_manifest(langs: list[str], limit: int | None) -> list[dict]:
+    if not MANIFEST.exists():
+        sys.exit("No clips cached — run with --fetch N first.")
+    items = [c for c in json.loads(MANIFEST.read_text()) if c["lang"] in langs]
+    if limit:  # keep the classes balanced when trimming
+        keep, counts = [], {}
+        for c in items:
+            key = (c["lang"], c["complete"])
+            if counts.get(key, 0) < limit // (2 * len(langs)):
+                counts[key] = counts.get(key, 0) + 1
+                keep.append(c)
+        items = keep
+    return items
+
+
+# ── judges ────────────────────────────────────────────────────────────────
+
+def judge_smart(detector, audio: np.ndarray, _b64: str) -> tuple[bool, float]:
+    with contextlib.redirect_stdout(io.StringIO()):  # it logs every call
+        complete, prob = detector.predict(audio)
+    return complete, prob
+
+
+def judge_marker(server, _audio, b64: str) -> tuple[bool, float]:
+    """Production `marker` path, stopped after the marker token: the reply
+    text costs the same whichever way the marker went, so decision latency
+    is what turn-taking actually feels."""
+    messages = [
+        {"role": "system", "content": server.SYSTEM_PROMPT},
+        {"role": "user", "content": [
+            server.audio_part(b64),
+            server.text_part(server.marker_instruction({}, False, True))]},
+    ]
+    return _marker_verdict(server, server.chat_blocking(messages, max_tokens=8))
+
+
+def judge_two_phase(server, _audio, b64: str) -> tuple[bool, float]:
+    messages = [
+        {"role": "system", "content": server.SYSTEM_PROMPT_TWO_PHASE},
+        {"role": "user", "content": [
+            server.audio_part(b64), server.text_part(server.DECISION_PROMPT)]},
+    ]
+    return _marker_verdict(server, server.chat_blocking(messages, max_tokens=6))
+
+
+def _marker_verdict(server, text: str) -> tuple[bool, float]:
+    """A missing or garbled marker counts as 'complete' — that is what
+    StreamParser falls back to in production."""
+    match = server.MARKER_RE.match(text.strip())
+    kind = server.MARKER_KINDS.get(match.group(1)) if match else None
+    return kind != "incomplete", 1.0 if kind is None else float(kind == "complete")
+
+
+JUDGES = {"smart": judge_smart, "marker": judge_marker, "two_phase": judge_two_phase}
+
+
+# ── scoring ───────────────────────────────────────────────────────────────
+
+def percentile(values: list[float], pct: float) -> float:
+    return round(float(np.percentile(values, pct)), 1) if values else 0.0
+
+
+def score(results: list[dict]) -> dict:
+    tp = sum(r["truth"] and r["pred"] for r in results)
+    tn = sum(not r["truth"] and not r["pred"] for r in results)
+    fp = sum(not r["truth"] and r["pred"] for r in results)
+    fn = sum(r["truth"] and not r["pred"] for r in results)
+    latencies = [r["ms"] for r in results]
+    n_complete, n_incomplete = tp + fn, tn + fp
+    return {
+        "n": len(results),
+        "accuracy": round((tp + tn) / len(results), 3),
+        # Missing a finished turn = dead air; the user waits for a reply.
+        "recall_complete": round(tp / n_complete, 3) if n_complete else None,
+        # Cutting in on an unfinished turn — the interruption users hate.
+        "recall_incomplete": round(tn / n_incomplete, 3) if n_incomplete else None,
+        "interrupt_rate": round(fp / n_incomplete, 3) if n_incomplete else None,
+        "confusion": {"tp": tp, "tn": tn, "fp": fp, "fn": fn},
+        "ms_p50": percentile(latencies, 50),
+        "ms_p95": percentile(latencies, 95),
+    }
+
+
+def sweep_threshold(results: list[dict]) -> dict:
+    """Accuracy vs the p(complete) cutoff in turn_detector.py. Raising it
+    trades dead air (waiting on a finished turn) for interruptions, which
+    are the more jarring failure — worth tuning against real speech."""
+    if len({r["prob"] for r in results}) < 3:  # marker modes emit 0.0/1.0
+        return {}
+    sweep = {}
+    for cut in (0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8):
+        scored = [{**r, "pred": r["prob"] > cut} for r in results]
+        stats = score(scored)
+        sweep[f"{cut:.1f}"] = {k: stats[k] for k in
+                               ("accuracy", "recall_complete", "interrupt_rate")}
+    return sweep
+
+
+def score_by_lang(results: list[dict]) -> dict:
+    langs = sorted({r["lang"] for r in results})
+    if len(langs) < 2:
+        return {}
+    return {l: score([r for r in results if r["lang"] == l]) for l in langs}
+
+
+def run_mode(mode: str, clips: list[dict], server, detector) -> list[dict]:
+    judge = JUDGES[mode]
+    ctx = detector if mode == "smart" else server
+    results = []
+    for i, clip in enumerate(clips, 1):
+        raw = (CLIPS_DIR / f"{clip['id']}.wav").read_bytes()
+        b64 = base64.b64encode(raw).decode()
+        audio = server.wav_to_float32(b64)
+        t0 = time.time()
+        pred, prob = judge(ctx, audio, b64)
+        results.append({"id": clip["id"], "lang": clip["lang"],
+                        "truth": clip["complete"], "pred": bool(pred),
+                        "prob": round(prob, 3), "ms": (time.time() - t0) * 1000})
+        if i % 25 == 0 or i == len(clips):
+            print(f"  {mode}: {i}/{len(clips)}")
+    return results
+
+
+def report(label: str, stats: dict) -> None:
+    print(f"{label:<22} acc {stats['accuracy']:.3f}   "
+          f"finished {stats['recall_complete']:.3f}   "
+          f"unfinished {stats['recall_incomplete']:.3f}   "
+          f"interrupts {stats['interrupt_rate']:.3f}   "
+          f"{stats['ms_p50']:.0f}ms p50 / {stats['ms_p95']:.0f}ms p95")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fetch", type=int, metavar="N",
+                    help="cache N clips per class per language, then exit")
+    ap.add_argument("--langs", default="eng", help="ISO 639-3 codes, comma separated")
+    ap.add_argument("--synthetic", action="store_true",
+                    help="also fetch TTS clips — the only kind that exists for most "
+                         "non-English languages, but their prosody always reads as "
+                         "finished, so acoustic scores from them are pessimistic")
+    ap.add_argument("--modes", default="smart,marker,two_phase")
+    ap.add_argument("--model", default="e2b", choices=list(MODELS))
+    ap.add_argument("--limit", type=int, help="score only the first N clips")
+    ap.add_argument("--out", help="write the full per-clip results here")
+    args = ap.parse_args()
+
+    langs = args.langs.split(",")
+    if args.fetch:
+        fetch_clips(langs, args.fetch, args.synthetic)
+        return
+
+    modes = args.modes.split(",")
+    clips = load_manifest(langs, args.limit)
+    print(f"{len(clips)} clips ({sum(c['complete'] for c in clips)} finished) "
+          f"| model {args.model} | modes {', '.join(modes)}")
+
+    if set(modes) - {"smart"}:
+        from huggingface_hub import hf_hub_download
+        repo, weights, mmproj = MODELS[args.model]
+        os.environ["MODEL_PATH"] = hf_hub_download(repo, weights, local_files_only=True)
+        os.environ["MMPROJ_PATH"] = hf_hub_download(repo, mmproj, local_files_only=True)
+        os.environ["LLAMA_PORT"] = BENCH_PORT
+
+    import server  # after the env above; it reads LLAMA_PORT at import
+    detector = None
+    if "smart" in modes:
+        from turn_detector import TurnDetector
+        detector = TurnDetector()
+    if set(modes) - {"smart"}:
+        server.start_llama_server()
+
+    try:
+        out = {"model": args.model, "langs": langs, "modes": {}}
+        for mode in modes:
+            results = run_mode(mode, clips, server, detector)
+            out["modes"][mode] = {"stats": score(results),
+                                  "by_lang": score_by_lang(results),
+                                  "threshold_sweep": sweep_threshold(results),
+                                  "results": results}
+    finally:
+        if server.llama_proc:
+            server.llama_proc.terminate()
+
+    print()
+    for mode in modes:
+        label = f"{mode} ({args.model})" if mode != "smart" else "smart (no LLM)"
+        report(label, out["modes"][mode]["stats"])
+        for lang, stats in out["modes"][mode]["by_lang"].items():
+            report(f"  └ {lang}", stats)
+        for cut, stats in out["modes"][mode]["threshold_sweep"].items():
+            print(f"  └ p>{cut}                acc {stats['accuracy']:.3f}   "
+                  f"finished {stats['recall_complete']:.3f}   "
+                  f"interrupts {stats['interrupt_rate']:.3f}")
+    if args.out:
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).write_text(json.dumps(out, indent=2))
+        print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/index.html
+++ b/src/index.html
@@ -1037,8 +1037,8 @@ async function init() {
     getStream: async () => new MediaStream(mediaStream.getAudioTracks()),
     positiveSpeechThreshold: 0.5,
     negativeSpeechThreshold: 0.25,
-    // Short redemption for fast turn-taking; the LLM's turn markers catch
-    // the cases where the user was merely pausing (see SYSTEM_PROMPT).
+    // Short redemption for fast turn-taking; the server's smart-turn
+    // classifier catches the cases where the user was merely pausing.
     redemptionMs: 200,
     minSpeechMs: 300,
     preSpeechPadMs: 300,

--- a/src/server.py
+++ b/src/server.py
@@ -54,94 +54,30 @@ LLAMA_PORT = int(os.environ.get("LLAMA_PORT", "8081"))
 LLAMA_URL = os.environ.get("LLAMA_SERVER_URL", "")  # set to use an external server
 LLAMA_CTX = int(os.environ.get("LLAMA_CTX", "16384"))
 
-# The reply streams straight into TTS, so the format is: response first
-# (sentences are spoken as they decode), transcript last (it never delays
-# first audio). Incomplete turns cost only a couple of decode tokens.
+# Turn completeness is judged by the smart-turn audio classifier before the
+# LLM is involved, so the prompt carries no FINISHED/WAIT machinery at all.
+# Asking Gemma to judge it instead scores at chance on audio — see
+# benchmarks/turnbench.py, which still reproduces those two variants.
 SYSTEM_PROMPT = (
-    "You are a friendly, conversational AI assistant. The user talks to you "
-    "through a microphone and may show you their camera. Your reply is spoken "
-    "aloud, so write plain conversational text: 1-4 short sentences, no formatting.\n"
-    "\n"
-    "Your reply MUST start with exactly one of these words on its own line, "
-    "judging the user's speech:\n"
-    "- FINISHED — the user completed their thought. Continue with your spoken "
-    "response on the next line.\n"
-    "- WAIT — the user has not finished: they were cut off mid-sentence or are "
-    "pausing to think. Say nothing else and let them continue.\n"
-    "Also reply WAIT if the audio is just an echo of your own previous reply "
-    "(the microphone picking up your voice) or is silence or noise.\n"
-    "\n"
-    "If the user sent audio, end your reply with a new line:\n"
-    "###TRANSCRIPT: the exact words the user said\n"
-    "\n"
-    "Examples:\n"
-    'User audio: "What\'s your favorite color?"\n'
-    "You: FINISHED\n"
-    "I really like deep blue. What about you?\n"
-    "###TRANSCRIPT: What's your favorite color?\n"
-    "\n"
-    'User audio with camera image: "Is this too much salt?"\n'
-    "You: FINISHED\n"
-    "That looks like a good amount for a pot that size.\n"
-    "###TRANSCRIPT: Is this too much salt?\n"
-    "\n"
-    'User audio: "So the thing I wanted to say is"\n'
-    "You: WAIT\n"
-    "\n"
-    'User audio: "Hmm, let me think about that for a second."\n'
-    "You: WAIT\n"
-)
-
-NUDGE_PROMPT = (
-    "(The user went quiet without finishing their thought. Reply FINISHED, then "
-    "in one short, warm sentence encourage them to continue. No transcript line.)"
-)
-
-# How turn completeness ("did the user finish their thought?") is judged:
-#   smart     — the smart-turn-v3 audio classifier decides in ~30ms and the
-#               LLM never sees marker instructions at all (default; E2B judged
-#               too unreliably at this in live testing)
-#   marker    — the LLM starts every reply with FINISHED/WAIT
-#   two_phase — a separate tiny LLM decision request, then a clean response
-TURN_MODE = os.environ.get("TURN_MODE", "smart")  # smart | marker | two_phase
-
-SYSTEM_PROMPT_TWO_PHASE = (
     "You are a friendly, conversational AI assistant. The user talks to you "
     "through a microphone and may show you their camera. Your replies are "
     "spoken aloud, so write plain conversational text without formatting."
 )
 
-DECISION_PROMPT = (
-    "The user just spoke. Judge ONLY whether they finished their thought — "
-    "do not answer them yet. Examples:\n"
-    '"What is your favorite food?" -> FINISHED\n'
-    '"I moved here last year and I want to know how I can make more friends." -> FINISHED\n'
-    '"So the thing I wanted to ask is" -> WAIT\n'
-    '"Hmm, let me think about that." -> WAIT\n'
-    "Reply with exactly one word: FINISHED or WAIT."
-)
-
+# The reply streams straight into TTS, so the format is: response first
+# (sentences are spoken as they decode), transcript last (it never delays
+# first audio).
 RESPOND_PROMPT = (
     "Respond to what the user said in their audio message: 1-4 short "
     "sentences, spoken aloud.{camera} Then end your reply with a new line: "
     "###TRANSCRIPT: followed by the exact words the user said."
 )
 
-NUDGE_PROMPT_TWO_PHASE = (
+NUDGE_PROMPT = (
     "(The user went quiet without finishing their thought. In one short, warm "
     "sentence, encourage them to continue. No transcript line.)"
 )
 
-# Accept close marker variants ("FINISH", trailing colon, markdown wrap) —
-# they never appear as the first word of a real response in uppercase.
-MARKER_RE = re.compile(r"[\s*_]*(FINISHED|FINISH|WAITING|WAIT)\b[:.]?[\s*_]*")
-MARKER_KINDS = {
-    "FINISHED": "complete",
-    "FINISH": "complete",
-    "WAIT": "incomplete_short",
-    "WAITING": "incomplete_short",
-}
-MARKER_HOLDBACK = 10  # chars of non-marker text before we give up waiting
 TRANSCRIPT_TAG = "###TRANSCRIPT:"
 SENTENCE_END_RE = re.compile(r"[.!?]+\s")
 MAX_OUTPUT_TOKENS = 256
@@ -156,7 +92,7 @@ _DONE = object()
 
 llama_proc = None
 tts_backend = None
-detector = None  # smart-turn classifier (TURN_MODE=smart)
+detector = None  # smart-turn end-of-turn classifier
 
 
 def resolve_model_paths() -> tuple[str, str]:
@@ -221,9 +157,8 @@ def start_llama_server():
 def load_models():
     global tts_backend, detector
     start_llama_server()
-    if TURN_MODE == "smart":
-        from turn_detector import TurnDetector
-        detector = TurnDetector()
+    from turn_detector import TurnDetector
+    detector = TurnDetector()
     tts_backend = tts.load()
 
 
@@ -375,8 +310,7 @@ def estimate_tokens(messages: list) -> int:
 # ── streaming turn parser (unchanged semantics from the litert version) ───
 
 class StreamParser:
-    """Incrementally parses 'FINISHED\\n<response>\\n###TRANSCRIPT: <words>',
-    where the first line may instead be a lone WAIT turn marker.
+    """Incrementally parses '<response>\\n###TRANSCRIPT: <words>'.
 
     feed() returns complete response sentences as they become available;
     finalize() returns the trailing partial sentence and the transcript.
@@ -385,43 +319,13 @@ class StreamParser:
     # Hold back enough of the tail to never TTS a partially-arrived tag.
     TAG_HOLDBACK = len(TRANSCRIPT_TAG) + 2
 
-    def __init__(self, expect_marker: bool = True):
-        # Without a marker (two-phase mode) everything is response text.
-        self.kind = None if expect_marker else "complete"
+    def __init__(self):
         self.response = ""
         self.transcript = ""
-        self._pending = ""  # text held until marker-vs-response is decided
         self._in_transcript = False
         self._emitted = 0
 
-    def _decide_kind(self, final: bool) -> tuple[str, str]:
-        """Returns (kind, response remainder) — kind '' means keep holding."""
-        m = MARKER_RE.match(self._pending)
-        if m:
-            if not final and m.end() == len(self._pending):
-                # "FINISH" may still grow into "FINISHED" — deciding now would
-                # leave the trailing "ED" to be spoken as response text.
-                return "", ""
-            return MARKER_KINDS[m.group(1)], self._pending[m.end():]
-        stripped = self._pending.lstrip()
-        if not final and len(stripped) < MARKER_HOLDBACK:
-            return "", ""
-        # Model skipped the marker — treat everything as the response.
-        return "complete", stripped
-
-    def feed(self, delta: str, final: bool = False) -> list[str]:
-        if self.kind is None:
-            self._pending += delta
-            kind, remainder = self._decide_kind(final)
-            if not kind:
-                return []
-            self.kind = kind
-            if kind != "complete":
-                return []
-            delta, self._pending = remainder.lstrip(), ""
-        elif self.kind != "complete":
-            return []  # marker turn: ignore any trailing text
-
+    def feed(self, delta: str) -> list[str]:
         if self._in_transcript:
             self.transcript += delta
             return []
@@ -455,7 +359,7 @@ class StreamParser:
         return sentences
 
     def finalize(self) -> tuple[list[str], str | None]:
-        sentences = self.feed("", final=True)
+        sentences = self.feed("")
         # Cut any (possibly truncated) transcript tag — never speak it.
         tail = re.split(r"#{2,}", self.response[self._emitted:])[0].strip()
         transcript = self.transcript.strip() or None
@@ -465,14 +369,13 @@ class StreamParser:
 # ── turn execution ────────────────────────────────────────────────────────
 
 async def run_turn(ws: WebSocket, messages: list, interrupted: asyncio.Event,
-                   active: dict, expect_marker: bool = True,
-                   extra_timings: dict | None = None) -> str:
+                   active: dict) -> str:
     """Stream one model turn: decode → sentences → TTS, all pipelined.
     Returns the raw generated text (stored verbatim in history so the next
     request gets a full prefix-cache hit)."""
     loop = asyncio.get_event_loop()
     t0 = time.time()
-    timings = dict(extra_timings or {})
+    timings: dict = {}
 
     chunk_q: asyncio.Queue = asyncio.Queue()
     stream = ChatStream(messages, MAX_OUTPUT_TOKENS)
@@ -520,7 +423,7 @@ async def run_turn(ws: WebSocket, messages: list, interrupted: asyncio.Event,
             audio_state["chunks"] += 1
 
     tts_task = asyncio.create_task(tts_worker())
-    parser = StreamParser(expect_marker=expect_marker)
+    parser = StreamParser()
     tts_started_at = None
 
     async def dispatch(sentences: list[str]):
@@ -546,13 +449,6 @@ async def run_turn(ws: WebSocket, messages: list, interrupted: asyncio.Event,
         tail, transcript = parser.finalize()
         timings["llm_time"] = round(time.time() - t0, 3)
         timings["decode_s"] = round(timings["llm_time"] - timings.get("prefill_s", 0), 3)
-
-        if parser.kind in ("incomplete_short", "incomplete_long"):
-            kind = parser.kind.removeprefix("incomplete_")
-            print(f"LLM ({timings['llm_time']:.2f}s) turn incomplete ({kind})")
-            if not interrupted.is_set():
-                await ws.send_text(json.dumps({"type": "turn_incomplete", "kind": kind, **timings}))
-            return raw["text"]
 
         if not interrupted.is_set():
             await dispatch(tail)
@@ -623,16 +519,12 @@ def wav_to_float32(b64: str) -> np.ndarray:
     return pcm.astype(np.float32) / 32768.0
 
 
-def marker_instruction(msg: dict, has_image: bool, has_audio: bool) -> str:
+def turn_instruction(msg: dict, has_image: bool, has_audio: bool) -> str:
     if msg.get("type") == "nudge":
-        return NUDGE_PROMPT if TURN_MODE == "marker" else NUDGE_PROMPT_TWO_PHASE
+        return NUDGE_PROMPT
     if has_audio:
-        base = ("The user just spoke while showing their camera. Start with FINISHED or WAIT, "
-                "then respond to what they said, referencing what you see if relevant."
-                if has_image else
-                "The user just spoke to you. Start with FINISHED or WAIT, then respond to "
-                "what they said.")
-        return base + " End with the ###TRANSCRIPT line."
+        camera = " Mention what you see on their camera if relevant." if has_image else ""
+        return RESPOND_PROMPT.format(camera=camera)
     if has_image:
         return "The user is showing you their camera. Describe what you see."
     return msg.get("text", "Hello!")
@@ -642,8 +534,7 @@ def marker_instruction(msg: dict, has_image: bool, has_audio: bool) -> str:
 async def websocket_endpoint(ws: WebSocket):
     await ws.accept()
 
-    system = SYSTEM_PROMPT if TURN_MODE == "marker" else SYSTEM_PROMPT_TWO_PHASE
-    history: list = [{"role": "system", "content": system}]
+    history: list = [{"role": "system", "content": SYSTEM_PROMPT}]
 
     interrupted = asyncio.Event()
     active = {"stream": None}
@@ -722,10 +613,10 @@ async def websocket_endpoint(ws: WebSocket):
                 }))
                 continue
 
-            # Smart mode: the audio classifier judges completeness before the
-            # LLM is involved at all. Incomplete → hold the segments (they stay
-            # in the next turn's content AND warm in the cache) and wait.
-            if TURN_MODE == "smart" and has_audio and msg.get("type") != "nudge":
+            # The audio classifier judges completeness before the LLM is
+            # involved at all. Incomplete → hold the segments (they stay in
+            # the next turn's content AND warm in the cache) and wait.
+            if has_audio and msg.get("type") != "nudge":
                 pcm = np.concatenate([wav_to_float32(b) for b in audio_b64s])
                 t0d = time.time()
                 complete, prob = await asyncio.get_event_loop().run_in_executor(
@@ -747,43 +638,9 @@ async def websocket_endpoint(ws: WebSocket):
             held_audio = []
 
             try:
-                if TURN_MODE == "two_phase" and has_audio:
-                    decision_messages = history + [
-                        {"role": "user", "content": content + [text_part(DECISION_PROMPT)]}]
-                    t0 = time.time()
-                    verdict_text = await asyncio.get_event_loop().run_in_executor(
-                        None, lambda: chat_blocking(decision_messages, max_tokens=6))
-                    decision_s = round(time.time() - t0, 3)
-                    print(f"Decision ({decision_s:.2f}s): {verdict_text.strip()!r}")
-                    if interrupted.is_set():
-                        continue
-                    if "WAIT" in verdict_text.upper():
-                        # Keep the unfinished audio in history — it is context
-                        # for the user's continuation.
-                        history.append(decision_messages[-1])
-                        history.append({"role": "assistant", "content": "WAIT"})
-                        await ws.send_text(json.dumps({
-                            "type": "turn_incomplete", "kind": "short",
-                            "decision_s": decision_s,
-                        }))
-                        continue
-                    camera = (" Mention what you see on their camera if relevant."
-                              if has_image else "")
-                    user_msg = {"role": "user",
-                                "content": content + [text_part(RESPOND_PROMPT.format(camera=camera))]}
-                    raw_text = await run_turn(ws, history + [user_msg], interrupted, active,
-                                              expect_marker=False,
-                                              extra_timings={"decision_s": decision_s})
-                else:
-                    if TURN_MODE == "smart" and has_audio and msg.get("type") != "nudge":
-                        camera = (" Mention what you see on their camera if relevant."
-                                  if has_image else "")
-                        instruction = RESPOND_PROMPT.format(camera=camera)
-                    else:
-                        instruction = marker_instruction(msg, has_image, has_audio)
-                    user_msg = {"role": "user", "content": content + [text_part(instruction)]}
-                    raw_text = await run_turn(ws, history + [user_msg], interrupted, active,
-                                              expect_marker=(TURN_MODE == "marker"))
+                instruction = turn_instruction(msg, has_image, has_audio)
+                user_msg = {"role": "user", "content": content + [text_part(instruction)]}
+                raw_text = await run_turn(ws, history + [user_msg], interrupted, active)
                 # Store the turn verbatim (same bytes → full prefix-cache hit
                 # on the next request). Never store a turn the model produced
                 # nothing for — a degenerate message poisons all later requests.


### PR DESCRIPTION
Stacked on #26 (`perf-latency`). Measures #26's three `TURN_MODE` options, then deletes the two that lose. Net **−197 lines** in `server.py`.

## Answer to "can E4B or 12B judge turns better than E2B?"

12B is genuinely better than E2B/E4B — and still not close to the 8M-parameter classifier it would replace.

| Mode | Model | Accuracy | Interrupt rate | p50 decision |
|---|---|---|---|---|
| **smart** (smart-turn-v3.2) | — | **0.960** | **0.070** | **19ms** |
| marker | E2B | 0.500 | 1.000 | 664ms |
| marker | E4B | 0.500 | 1.000 | 1179ms |
| marker | 12B | 0.660 | 0.640 | 3578ms |
| two_phase | E2B | 0.560 | 0.000 | 619ms |
| two_phase | E4B | 0.500 | 1.000 | 1123ms |
| two_phase | 12B | 0.660 | 0.680 | 3766ms |

`smart` on 200 real English clips, LLM rows on 50. *Interrupt rate* = unfinished turns wrongly judged finished, i.e. cutting the user off.

E2B and E4B are degenerate — they answer one label to everything (E2B two_phase answers WAIT to almost everything, which is why its 0.560 comes with 0.120 finished-recall: it would simply never reply). **E4B buys nothing over E2B at double the latency.** 12B actually discriminates, but trails smart-turn by 30 points, interrupts on two thirds of unfinished turns, and takes 3.5s to decide.

**Verdict: ship the classifier alone.** `TURN_MODE` is gone.

## Why the LLM modes fail — the audio path, not the prompt

#26 tried five prompt variants. The cause is narrower:

- Asked to **transcribe** the same clips, E4B is accurate — the audio arrives intact.
- Judging that **transcript as text**: 14/20. Judging the **audio**: 10/20.

The turn signal survives into the transcript and is destroyed in the FINISHED/WAIT decision when the input is audio. No prompt rewrite recovers that; only an ASR-first architecture would, at the cost of a full transcription pass to land below an 8M-parameter model. llama.cpp also still marks Gemma audio input experimental.

## What the removal takes with it

The marker regex and kinds, two extra system prompts, the two_phase decision request, `run_turn`'s `expect_marker` and its incomplete path, and StreamParser's entire marker branch — the parser is now just response-then-transcript. Completeness is decided before the LLM is called, so any turn reaching `run_turn` is complete by construction.

`benchmarks/turnbench.py` keeps both prompts, so the comparison re-runs against the next Gemma without digging them out of git history.

## Correction

The first commit's numbers were wrong. `_marker_verdict` compared against `"incomplete"` while `MARKER_KINDS` maps WAIT to `"incomplete_short"`, so every LLM verdict parsed as complete — which is what produced the tidy "all three sit at 0.500". Fixed in 2b67767; the table above is the corrected run. The conclusion did not change, but "12B is at chance" was wrong.

## Benchmark used

[`pipecat-ai/smart-turn-data-v3.2-test`](https://huggingface.co/datasets/pipecat-ai/smart-turn-data-v3.2-test) — 31,527 clips, 23 languages, `endpoint_bool` ground truth. Fetched via the HF datasets-server REST API and cached as 16kHz WAVs, so no new dependency.

Restricted to `synthetic=false`: TTS clips read as finished whatever the words are — the same effect that makes #26's `thinking_suppressed` check fail by construction. Note **all 971 Indonesian clips are synthetic**, so this set cannot validate the Bule-AI multilingual case; `--synthetic` opts in with that caveat.

**This is smart-turn's own test split**, so 0.960 is in-domain and optimistic. [LiveKit's eot-bench](https://github.com/livekit/eot-bench) (Apache-2.0, 14 real languages including Indonesian) scores smart-turn v3.2 at 35.2% false cutoffs against a 300ms budget — the independent cross-check worth running.

## Threshold: left at pipecat's default

`turn_detector.py:56` uses `probability > 0.5`, which matches pipecat's own default ([`local_smart_turn_v3.py:174`](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/audio/turn/smart_turn/local_smart_turn_v3.py)). Unchanged. For the record, 0.6 scored better on this data (0.975 accuracy, interrupts 0.070 → 0.030), but that is a 200-clip in-domain tune against an upstream default, so it stays as a note.

Worth a follow-up: pipecat pairs the classifier with `stop_secs=3`, a silence fallback that force-completes a turn regardless of the classifier. Parlor has no equivalent — it nudges instead.

## Verification

`benchmarks/bench.py` against the rebuilt server: every correctness check passes except `thinking_suppressed` (documented in #26 as failing by construction). Latencies unchanged — `audio_short` first audio 0.573s, `audio_long` 0.688s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)