### PR TITLE
GPT-Live features: background-reasoner delegation + live translation mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,35 @@
-# Path to a local Gemma 4 E2B model (optional — auto-downloads from HuggingFace if not set)
-# MODEL_PATH=/path/to/gemma-4-E2B-it.litertlm
+# ── Voice model (llama.cpp) ──────────────────────────────────────────────
+# Model size: e2b | e4b | 12b (Google's official QAT q4_0 GGUFs,
+# auto-downloaded from HuggingFace on first run). e4b is the default.
+# MODEL=e4b
 
-# Server port (default: 8000)
+# Or point at local GGUF files instead (both required together):
+# MODEL_PATH=/path/to/model.gguf
+# MMPROJ_PATH=/path/to/mmproj.gguf
+
+# llama-server tuning; LLAMA_SERVER_URL uses an external server instead of
+# spawning one.
+# LLAMA_PORT=8081
+# LLAMA_CTX=16384
+# TEMPERATURE=0.7
+# LLAMA_SERVER_URL=
+
+# ── Web server ───────────────────────────────────────────────────────────
 # PORT=8000
+
+# ── TTS ──────────────────────────────────────────────────────────────────
+# Force the ONNX backend even on Apple Silicon:
+# KOKORO_ONNX=1
+
+# ── Background reasoner (delegation) ─────────────────────────────────────
+# When a question needs web search or deep research, the voice model can
+# hand it to a frontier model on any OpenAI-compatible endpoint and weave
+# the answer back into the conversation. Off unless REASONER_API_KEY is
+# set — without it Parlor stays fully on-device.
+# REASONER_API_KEY=sk-or-...
+# REASONER_BASE_URL=https://openrouter.ai/api/v1
+# REASONER_MODEL=anthropic/claude-sonnet-4.5
+# On OpenRouter, web search is enabled by appending ':online' to the model
+# (set 0 to disable):
+# REASONER_WEB_SEARCH=1
+# REASONER_TIMEOUT=90

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Browser (playback + transcript)
 - **Speculative prefill during speech.** The camera frame is sent the moment you start speaking, and your speech itself streams to the server in ~3s chunks — both are pushed through llama.cpp's prompt cache while you're still talking, so at the end of a long question almost everything is already processed.
 - **Barge-in.** Interrupt the AI mid-sentence by speaking; generation is aborted server-side. Echo is handled without the browser's echo canceller (which muffles both the TTS voice and your barge-in on macOS): a sustained-speech gate plus a prompt rule — or just wear headphones.
 - **Background research delegation** (optional). Ask something that needs web search or real reasoning — "find the best pizza in Rome right now" — and the local model hands the task to a frontier model on any OpenAI-compatible endpoint (OpenRouter by default, with web search), keeps the conversation going, and speaks the answer when it comes back. Off unless `REASONER_API_KEY` is set; without it Parlor stays fully on-device.
+- **Live translation mode.** Say "translate everything I say into English" and Parlor becomes a consecutive interpreter: each utterance is rendered in English after a short silence window (no turn-completeness holds, no conversational replies), in any language Gemma understands. Say "stop translating" — or hit the stop chip — to return to conversation. One-way into English for now; the TTS voice is per-mode, so more Kokoro output languages are a config away.
 
 ## Requirements
 
@@ -127,6 +128,7 @@ src/
 ├── llama.py               # llama-server lifecycle + chat API client
 ├── pipeline.py            # Streaming turn pipeline (decode → sentences → TTS)
 ├── reasoner.py            # Background research delegation (OpenAI-compatible)
+├── modes.py               # Session modes (conversation, translate)
 ├── turn_detector.py       # smart-turn-v3 end-of-turn classifier
 ├── whisper_features.py    # Log-mel features for the turn detector
 ├── tts.py                 # Platform-aware TTS (MLX on Mac, ONNX on Linux)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Browser (playback + transcript)
 - **Streaming decode → TTS.** The reply opens with a one-line transcript of what you said (committing to it first measurably improves both transcript and response accuracy, and it appears on screen immediately), then the response is spoken sentence-by-sentence while the model is still generating.
 - **Speculative prefill during speech.** The camera frame is sent the moment you start speaking, and your speech itself streams to the server in ~3s chunks — both are pushed through llama.cpp's prompt cache while you're still talking, so at the end of a long question almost everything is already processed.
 - **Barge-in.** Interrupt the AI mid-sentence by speaking; generation is aborted server-side. Echo is handled without the browser's echo canceller (which muffles both the TTS voice and your barge-in on macOS): a sustained-speech gate plus a prompt rule — or just wear headphones.
+- **Background research delegation** (optional). Ask something that needs web search or real reasoning — "find the best pizza in Rome right now" — and the local model hands the task to a frontier model on any OpenAI-compatible endpoint (OpenRouter by default, with web search), keeps the conversation going, and speaks the answer when it comes back. Off unless `REASONER_API_KEY` is set; without it Parlor stays fully on-device.
 
 ## Requirements
 
@@ -76,6 +77,11 @@ Models are downloaded automatically on first run (~5.7 GB for Gemma 4 E4B QAT + 
 | `LLAMA_CTX`        | `16384`                        | llama.cpp context size. The server drops the oldest exchanges shortly before it fills |
 | `LLAMA_PORT`       | `8081`                         | Port for the spawned llama-server              |
 | `LLAMA_SERVER_URL` | (spawn our own)                | Use an already-running llama-server instead    |
+| `REASONER_API_KEY` | (unset — delegation off)       | API key for the background reasoner endpoint   |
+| `REASONER_BASE_URL`| `https://openrouter.ai/api/v1` | Any OpenAI-compatible chat endpoint            |
+| `REASONER_MODEL`   | `anthropic/claude-sonnet-4.5`  | Model the endpoint should run                  |
+| `REASONER_WEB_SEARCH` | `1`                         | On OpenRouter, append `:online` for web search |
+| `REASONER_TIMEOUT` | `90`                           | Seconds before a background task fails         |
 
 ## Performance (Apple M3 Pro)
 
@@ -120,6 +126,7 @@ src/
 ├── server.py              # FastAPI app + per-connection conversation loop
 ├── llama.py               # llama-server lifecycle + chat API client
 ├── pipeline.py            # Streaming turn pipeline (decode → sentences → TTS)
+├── reasoner.py            # Background research delegation (OpenAI-compatible)
 ├── turn_detector.py       # smart-turn-v3 end-of-turn classifier
 ├── whisper_features.py    # Log-mel features for the turn detector
 ├── tts.py                 # Platform-aware TTS (MLX on Mac, ONNX on Linux)

--- a/src/benchmarks/fixtures.py
+++ b/src/benchmarks/fixtures.py
@@ -63,6 +63,35 @@ FIXTURES = {
         "Can you remind me what my name is?",
         ["name"],
     ),
+    # Transcript-stability fillers (tests/test_transcription_stability.py):
+    # each carries content words unique across the whole fixture set, so a
+    # transcript that borrows another turn's words is provably written from
+    # history, not from the audio. Plain statements on purpose — no
+    # search/current-info phrasing that would fire <delegate>.
+    "filler_color": (
+        "My favorite color is turquoise, like the sea near my childhood home.",
+        ["turquoise"],
+    ),
+    "filler_pet": (
+        "I adopted a golden retriever puppy last month and named him Biscuit.",
+        ["biscuit"],
+    ),
+    "filler_baking": (
+        "On weekends I like to bake sourdough bread with rosemary and olives.",
+        ["sourdough"],
+    ),
+    "filler_novel": (
+        "I have been reading a mystery novel set in Lisbon about a missing violin.",
+        ["lisbon"],
+    ),
+    "filler_jazz": (
+        "Lately I have been listening to a lot of jazz piano records in the evening.",
+        ["jazz"],
+    ),
+    "filler_garden": (
+        "This spring I want to plant tomatoes and basil on my balcony.",
+        ["basil"],
+    ),
     # Delegation e2e: explicit "search the web" phrasing so the model
     # reliably emits the <delegate> tag (see benchmarks/tagbench.py).
     "delegate_pizza": (
@@ -184,6 +213,26 @@ def generate_all(force: bool = False) -> None:
         pcm = _synthesize(backend, text, **kwargs)
         _write_wav(FIXTURES_DIR / f"{name}.wav", pcm, TARGET_SR)
         print(f"fixture {name}: {len(pcm) / TARGET_SR:.1f}s speech")
+
+
+def breath_wav_b64(seconds: float = 1.2, level: float = 0.03, seed: int = 7) -> str:
+    """Non-speech audio like a VAD false trigger captures: low-pass noise
+    with a breath-like swell (level scales the pre-envelope RMS). Long
+    enough to pass the server's valid_audio check, seeded so every run
+    sends identical bytes."""
+    n = int(seconds * TARGET_SR)
+    rng = np.random.default_rng(seed)
+    noise = np.convolve(rng.standard_normal(n).astype(np.float32),
+                        np.ones(48, dtype=np.float32) / 48, mode="same")
+    env = np.sin(np.linspace(0, np.pi, n)).astype(np.float32) ** 2
+    pcm = noise / (np.sqrt(np.mean(noise**2)) + 1e-9) * level * env
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(TARGET_SR)
+        w.writeframes((pcm * 32767).clip(-32768, 32767).astype(np.int16).tobytes())
+    return base64.b64encode(buf.getvalue()).decode()
 
 
 def load_wav_b64(name: str) -> str:

--- a/src/benchmarks/fixtures.py
+++ b/src/benchmarks/fixtures.py
@@ -85,6 +85,31 @@ FIXTURES = {
         "Can you search the web for today's weather in Naples, Italy?",
         ["weather", "naples"],
     ),
+    # Alternate phrasings for the delegation tests' retry: re-sending the
+    # SAME audio tends to reproduce the same tagless completion (cached
+    # prefix, near-deterministic sampling), so a retry only decorrelates
+    # with different words. Trigger keywords ('stock', 'naples') preserved.
+    "delegate_pizza_alt": (
+        "Please look up the best pizza places in Rome right now.",
+        ["pizza", "rome"],
+    ),
+    "delegate_stock_alt": (
+        "Please look up Apple's current stock price on the web for me.",
+        ["stock", "apple"],
+    ),
+    "delegate_naples_alt": (
+        "Please look up the current weather in Naples, Italy for me.",
+        ["weather", "naples"],
+    ),
+    # Mode-switch voice commands (translation e2e).
+    "cmd_translate": (
+        "From now on, please translate everything I say into English.",
+        ["translate"],
+    ),
+    "cmd_stop_translate": (
+        "Okay, stop translating now and go back to normal conversation.",
+        ["stop"],
+    ),
 }
 
 # Synthesis kwargs (see _synthesize) for base fixtures that need them.

--- a/src/benchmarks/fixtures.py
+++ b/src/benchmarks/fixtures.py
@@ -63,6 +63,28 @@ FIXTURES = {
         "Can you remind me what my name is?",
         ["name"],
     ),
+    # Delegation e2e: explicit "search the web" phrasing so the model
+    # reliably emits the <delegate> tag (see benchmarks/tagbench.py).
+    "delegate_pizza": (
+        "Can you search the web and find the best pizza place in Rome "
+        "right now?",
+        ["pizza", "rome"],
+    ),
+    # "stock" in the task makes the suite's mock reasoner fail the request
+    # (tests/conftest.py) — the failure path must end in a spoken apology.
+    "delegate_stock": (
+        "Can you search the web for the current stock price of Apple?",
+        ["stock", "apple"],
+    ),
+    # "naples" makes the mock stall 8s — long enough to prove the
+    # conversation continues while a background task runs. Current-info
+    # phrasing on purpose: for topics the model believes it knows (e.g.
+    # "the history of pizza") it acks without the tag often enough to
+    # flake, no matter how the request is worded.
+    "delegate_naples": (
+        "Can you search the web for today's weather in Naples, Italy?",
+        ["weather", "naples"],
+    ),
 }
 
 # Synthesis kwargs (see _synthesize) for base fixtures that need them.
@@ -75,7 +97,10 @@ BASE_KWARGS = {"incomplete_cutoff": {"keep_frac": 0.55}}
 VARIANTS = {
     "capital_france_clipped": ("capital_france", {"clip_end_s": 0.18}),
     "capital_france_noisy": ("capital_france", {"snr_db": 12}),
-    "long_question_male": ("long_question", {"voice": "am_michael"}),
+    # am_adam holds a clear margin below smart-turn's 0.5 threshold after
+    # the int16 WAV round-trip (0.25); am_michael sat at ~0.5 and flipped
+    # with synthesis drift, breaking the held-turn tests.
+    "long_question_male": ("long_question", {"voice": "am_adam"}),
 }
 
 

--- a/src/benchmarks/tagbench.py
+++ b/src/benchmarks/tagbench.py
@@ -1,0 +1,209 @@
+"""Control-tag emission benchmark — when a reply should carry an action
+tag, which syntax does the model emit more reliably: a '###DELEGATE: task'
+line (matching the existing ###TRANSCRIPT machinery) or an XML
+'<delegate>task</delegate>' element?
+
+Real synthesized speech goes through the production turn shape (audio part
++ transcript-first RESPOND_PROMPT) against a live llama-server, with the
+delegation instruction appended to the system prompt in each syntax.
+Scored per syntax:
+
+    recall    — well-formed tag on delegate-worthy turns (higher = better)
+    misfire   — any tag on ordinary turns (lower = better)
+    malformed — tag-ish output the strict extractor rejects
+    leaked    — tag fragments that would reach TTS and be spoken aloud
+
+    uv run python benchmarks/tagbench.py --repeat 2 \
+        --out benchmarks/results/tagbench-e4b.json
+
+Runs its own llama-server on port 8099 (like turnbench), so a dev server
+on 8081 can keep running. Fixture WAVs cache in fixtures/tagbench/.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+os.environ.setdefault("LLAMA_PORT", "8099")
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import fixtures  # noqa: E402
+import llama  # noqa: E402
+from pipeline import StreamParser, audio_part, text_part  # noqa: E402
+
+CACHE_DIR = Path(__file__).parent / "fixtures" / "tagbench"
+
+# Utterances that should trigger a delegation (need web search / current
+# data / deep research) and ordinary turns that must not.
+DELEGATE_CASES = {
+    "weather_tokyo": "What's the weather in Tokyo right now?",
+    "pizza_rome": "Can you find the best pizza places in Rome for my trip?",
+    "bitcoin_price": "Look up the current price of Bitcoin for me.",
+    "phone_reviews": "I want to buy a new phone. Can you research the latest "
+                     "reviews and tell me which one is best?",
+    "flight_deals": "Can you search for cheap flights from Jakarta to Tokyo "
+                    "next month?",
+    "news_today": "What are the biggest news stories today?",
+}
+PLAIN_CASES = {
+    "capital_france": "What is the capital of France?",
+    "how_are_you": "Hey, how are you doing today?",
+    "tell_joke": "Tell me a joke about cats.",
+    "long_day": "I had a really long day at work and I just want to chat.",
+    "english_advice": "Could you give me some advice on how to improve my "
+                      "English pronunciation?",
+    "what_is_rain": "Why does it rain more in the tropics?",
+}
+
+INSTRUCTION_COMMON = (
+    "\n\nYou can hand a task to a powerful background research assistant "
+    "that has web access. When the user asks for something that needs "
+    "current information, web search, or deep research you cannot do "
+    "yourself, briefly acknowledge the request in one short spoken "
+    "sentence, and end your reply with exactly one line like this:\n"
+    "{example}\n"
+    "The task must be self-contained. For anything you can answer "
+    "yourself, reply normally and never write {name}."
+)
+
+SYNTAXES = {
+    "hash": {
+        "example": "###DELEGATE: <the task>",
+        "name": "###DELEGATE",
+        # loose: did it attempt a tag at all; strict: would production parse it
+        "loose": re.compile(r"#{2,}\s*DELEGATE|DELEGATE\s*:", re.IGNORECASE),
+        "strict": re.compile(r"#{2,}[ \t]*DELEGATE[ \t]*:[ \t]*(?P<task>[^\n]+)",
+                             re.IGNORECASE),
+    },
+    "xml": {
+        "example": "<delegate>the task</delegate>",
+        "name": "<delegate>",
+        "loose": re.compile(r"<\s*/?\s*delegate|delegate\s*>", re.IGNORECASE),
+        "strict": re.compile(r"<delegate>\s*(?P<task>[^<]+?)\s*</delegate>",
+                             re.IGNORECASE),
+    },
+}
+
+# Mirrors server.py's production prompts (imported so drift is impossible).
+def production_prompts():
+    import server
+    return server.SYSTEM_PROMPT, server.RESPOND_PROMPT.format(camera="")
+
+
+def ensure_fixtures() -> dict[str, str]:
+    """name -> WAV base64, synthesizing any missing clips."""
+    cases = DELEGATE_CASES | PLAIN_CASES
+    missing = [n for n in cases if not (CACHE_DIR / f"{n}.wav").exists()]
+    if missing:
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        import tts
+        backend = tts.load()
+        for name in missing:
+            pcm = fixtures._synthesize(backend, cases[name])
+            fixtures._write_wav(CACHE_DIR / f"{name}.wav", pcm, fixtures.TARGET_SR)
+            print(f"fixture {name}: {len(pcm) / fixtures.TARGET_SR:.1f}s speech")
+    return {n: base64.b64encode((CACHE_DIR / f"{n}.wav").read_bytes()).decode()
+            for n in cases}
+
+
+def spoken_text(raw: str, syntax: str) -> str:
+    """What TTS would say: the XML path uses the real production parser
+    (which extracts <delegate> elements); the hash path simulates a
+    ###DELEGATE:-line parser by regex."""
+    if syntax == "xml":
+        p = StreamParser(expect_transcript=True, control_tags=("delegate",))
+        spoken = p.feed(raw)
+        tail, _ = p.finalize()
+        return " ".join(spoken + tail)
+    text = SYNTAXES["hash"]["strict"].sub("", raw)
+    m = re.search(r"#{2,}[ \t]*TRANSCRIPT[ \t]*:[^\n]*\n?", text, re.IGNORECASE)
+    if m:
+        text = text[m.end():]
+    return re.split(r"#{2,}", text)[0].strip()
+
+
+def judge(raw: str, syntax: str, expects_tag: bool) -> dict:
+    s = SYNTAXES[syntax]
+    strict = s["strict"].search(raw)
+    loose = bool(s["loose"].search(raw))
+    spoken = spoken_text(raw, syntax)
+    # Any tag residue in what gets spoken is the worst failure mode.
+    leaked = bool(re.search(r"delegate", spoken, re.IGNORECASE)) or "##" in spoken or "<" in spoken
+    return {
+        "expects_tag": expects_tag,
+        "well_formed": bool(strict),
+        "attempted": loose,
+        "malformed": loose and not strict,
+        "leaked": leaked,
+        "task": strict.group("task").strip() if strict else None,
+        "raw": raw,
+    }
+
+
+def score(results: list[dict]) -> dict:
+    pos = [r for r in results if r["expects_tag"]]
+    neg = [r for r in results if not r["expects_tag"]]
+    return {
+        "recall": round(sum(r["well_formed"] for r in pos) / len(pos), 3) if pos else None,
+        "misfire": round(sum(r["attempted"] for r in neg) / len(neg), 3) if neg else None,
+        "malformed": sum(r["malformed"] for r in results),
+        "leaked": sum(r["leaked"] for r in results),
+        "n": len(results),
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repeat", type=int, default=1)
+    ap.add_argument("--syntaxes", default="hash,xml")
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+
+    system, respond = production_prompts()
+    wavs = ensure_fixtures()
+    llama.start()
+    try:
+        out = {"model": llama.MODEL, "temperature": llama.TEMPERATURE,
+               "repeat": args.repeat, "syntaxes": {}}
+        for syntax in args.syntaxes.split(","):
+            s = SYNTAXES[syntax]
+            sys_prompt = system + INSTRUCTION_COMMON.format(
+                example=s["example"], name=s["name"])
+            results = []
+            for name, wav in wavs.items():
+                expects = name in DELEGATE_CASES
+                for _ in range(args.repeat):
+                    t0 = time.time()
+                    raw = llama.chat_blocking(
+                        [{"role": "system", "content": sys_prompt},
+                         {"role": "user", "content": [audio_part(wav),
+                                                      text_part(respond)]}],
+                        max_tokens=256)
+                    r = judge(raw, syntax, expects) | {"case": name}
+                    results.append(r)
+                    verdict = ("tag" if r["well_formed"] else
+                               "MALFORMED" if r["malformed"] else "plain")
+                    flag = " LEAKED" if r["leaked"] else ""
+                    ok = "✓" if (r["well_formed"] == expects and not r["malformed"]
+                                 and not r["leaked"]) else "✗"
+                    print(f"{ok} [{syntax}] {name}: {verdict}{flag} "
+                          f"({time.time() - t0:.1f}s)")
+            out["syntaxes"][syntax] = {"stats": score(results), "results": results}
+            print(f"\n{syntax}: {out['syntaxes'][syntax]['stats']}\n")
+    finally:
+        llama.stop()
+
+    if args.out:
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).write_text(json.dumps(out, indent=2))
+        print(f"Wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/benchmarks/tagbench.py
+++ b/src/benchmarks/tagbench.py
@@ -76,8 +76,10 @@ SYNTAXES = {
     "hash": {
         "example": "###DELEGATE: <the task>",
         "name": "###DELEGATE",
-        # loose: did it attempt a tag at all; strict: would production parse it
-        "loose": re.compile(r"#{2,}\s*DELEGATE|DELEGATE\s*:", re.IGNORECASE),
+        # loose: did it attempt a tag at all; strict: would production parse
+        # it. No bare 'DELEGATE:' alternative — that matches markup-free
+        # prose and would score misfires asymmetrically against hash.
+        "loose": re.compile(r"#{2,}\s*DELEGATE", re.IGNORECASE),
         "strict": re.compile(r"#{2,}[ \t]*DELEGATE[ \t]*:[ \t]*(?P<task>[^\n]+)",
                              re.IGNORECASE),
     },
@@ -90,10 +92,12 @@ SYNTAXES = {
     },
 }
 
+
 # Mirrors server.py's production prompts (imported so drift is impossible).
 def production_prompts():
     import server
-    return server.SYSTEM_PROMPT, server.RESPOND_PROMPT.format(camera="")
+    return (server.SYSTEM_PROMPT, server.RESPOND_PROMPT.format(camera=""),
+            server.DELEGATE_INSTRUCTION)
 
 
 def ensure_fixtures() -> dict[str, str]:
@@ -134,7 +138,7 @@ def judge(raw: str, syntax: str, expects_tag: bool) -> dict:
     loose = bool(s["loose"].search(raw))
     spoken = spoken_text(raw, syntax)
     # Any tag residue in what gets spoken is the worst failure mode.
-    leaked = bool(re.search(r"delegate", spoken, re.IGNORECASE)) or "##" in spoken or "<" in spoken
+    leaked = "delegate" in spoken.lower() or "##" in spoken or "<" in spoken
     return {
         "expects_tag": expects_tag,
         "well_formed": bool(strict),
@@ -162,19 +166,27 @@ def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--repeat", type=int, default=1)
     ap.add_argument("--syntaxes", default="hash,xml")
+    ap.add_argument("--production", action="store_true",
+                    help="bench server.py's DELEGATE_INSTRUCTION verbatim "
+                         "(the xml syntax it uses) instead of the symmetric "
+                         "A/B instruction — the regression guard for prompt "
+                         "changes")
     ap.add_argument("--out", default="")
     args = ap.parse_args()
 
-    system, respond = production_prompts()
+    system, respond, delegate_instruction = production_prompts()
     wavs = ensure_fixtures()
+    if args.production:
+        variants = [("production", system + delegate_instruction, "xml")]
+    else:
+        variants = [(s, system + INSTRUCTION_COMMON.format(
+                        example=SYNTAXES[s]["example"], name=SYNTAXES[s]["name"]), s)
+                    for s in args.syntaxes.split(",")]
     llama.start()
     try:
         out = {"model": llama.MODEL, "temperature": llama.TEMPERATURE,
                "repeat": args.repeat, "syntaxes": {}}
-        for syntax in args.syntaxes.split(","):
-            s = SYNTAXES[syntax]
-            sys_prompt = system + INSTRUCTION_COMMON.format(
-                example=s["example"], name=s["name"])
+        for label, sys_prompt, syntax in variants:
             results = []
             for name, wav in wavs.items():
                 expects = name in DELEGATE_CASES
@@ -192,10 +204,11 @@ def main() -> None:
                     flag = " LEAKED" if r["leaked"] else ""
                     ok = "✓" if (r["well_formed"] == expects and not r["malformed"]
                                  and not r["leaked"]) else "✗"
-                    print(f"{ok} [{syntax}] {name}: {verdict}{flag} "
+                    print(f"{ok} [{label}] {name}: {verdict}{flag} "
                           f"({time.time() - t0:.1f}s)")
-            out["syntaxes"][syntax] = {"stats": score(results), "results": results}
-            print(f"\n{syntax}: {out['syntaxes'][syntax]['stats']}\n")
+            stats = score(results)
+            out["syntaxes"][label] = {"stats": stats, "results": results}
+            print(f"\n{label}: {stats}\n")
     finally:
         llama.stop()
 

--- a/src/index.html
+++ b/src/index.html
@@ -38,6 +38,10 @@
   <!-- Controls -->
   <div class="controls">
     <button id="cameraToggle" class="ctrl-btn active">Camera On</button>
+    <div id="modeChip" class="mode-chip" hidden>
+      <span>Translating → English</span>
+      <button id="modeStop" class="mode-stop">stop</button>
+    </div>
     <div class="state-indicator">
       <div id="stateDot" class="dot loading"></div>
       <span id="stateText">Loading...</span>

--- a/src/llama.py
+++ b/src/llama.py
@@ -115,7 +115,7 @@ def stop() -> None:
 
 
 def _chat_body(messages: list, max_tokens: int, stream: bool) -> dict:
-    return {
+    body = {
         "messages": messages,
         "max_tokens": max_tokens,
         "temperature": TEMPERATURE,
@@ -123,6 +123,11 @@ def _chat_body(messages: list, max_tokens: int, stream: bool) -> dict:
         "cache_prompt": True,
         "chat_template_kwargs": {"enable_thinking": False},
     }
+    if stream:
+        # The final chunk then carries usage.prompt_tokens — the REAL
+        # context size, which drives history rotation (estimates drift).
+        body["stream_options"] = {"include_usage": True}
+    return body
 
 
 def chat_blocking(messages: list, max_tokens: int) -> str:
@@ -148,6 +153,7 @@ class ChatStream:
         self.body = _chat_body(messages, max_tokens, stream=True)
         self.conn = None
         self.cancelled = False
+        self.prompt_tokens: int | None = None  # real count, from the usage chunk
 
     def run(self, on_delta):
         # self.conn is published before the request is sent, so a cancel()
@@ -173,8 +179,12 @@ class ChatStream:
                 payload = line[6:]
                 if payload == b"[DONE]":
                     break
-                delta = json.loads(payload)["choices"][0].get("delta", {})
-                text = delta.get("content")
+                chunk = json.loads(payload)
+                usage = chunk.get("usage")
+                if usage and usage.get("prompt_tokens"):
+                    self.prompt_tokens = usage["prompt_tokens"]
+                choices = chunk.get("choices") or []
+                text = choices[0].get("delta", {}).get("content") if choices else None
                 if text:
                     on_delta(text)
         except Exception as e:

--- a/src/modes.py
+++ b/src/modes.py
@@ -1,0 +1,34 @@
+"""Session modes: what kind of interaction the session is in decides how
+turns are gated and prompted. The default is open conversation; 'translate'
+turns Parlor into a consecutive interpreter — every utterance is rendered
+in English on a short silence window, with no conversational replies.
+
+A mode is data, not behavior: server.py consults these flags instead of
+hardcoding, so a future mode (an interpreter pair, camera narration) is a
+new entry here plus whatever new trigger it needs, not a rewrite of the
+turn loop. Switching is model-driven — the voice model emits a
+<mode>name</mode> control tag when the user asks — with a UI escape hatch
+(the client's mode chip sends set_mode directly).
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Mode:
+    name: str
+    uses_smart_turn: bool     # acoustic completeness gate + hold/flush
+    allows_delegation: bool   # background-reasoner tag and deliveries
+    wants_camera: bool        # accept + cache-prime camera frames
+    tts_voice: str            # per-mode Kokoro voice (carries the language)
+
+
+MODES = {m.name: m for m in [
+    Mode("conversation", uses_smart_turn=True, allows_delegation=True,
+         wants_camera=True, tts_voice="af_heart"),
+    # An interpreter waits only for a short silence, never for a "complete
+    # thought" — a mid-sentence thinking pause must not stall translation —
+    # and never mixes research or camera chatter into the rendering.
+    Mode("translate", uses_smart_turn=False, allows_delegation=False,
+         wants_camera=False, tts_voice="af_heart"),
+]}

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -339,6 +339,18 @@ def _norm_words(text: str) -> list[str]:
     return re.sub(r"[^a-z0-9' ]+", " ", text.lower()).split()
 
 
+# A transcript that is entirely a bracketed annotation — the sanctioned
+# "(no speech)" from the turn prompts, or free-form variants the model
+# produces on its own ("(noise)", "[Silence]", "*sigh*", "(background
+# noise)") — reports that there were no words. It must never be shown or
+# stored as user words. Real transcripts are plain words, never fully
+# bracketed; the length cap keeps a genuine parenthesized ramble out.
+NO_SPEECH_RE = re.compile(
+    r"^(?:\(\s*[^)]{1,40}\)|\[\s*[^\]]{1,40}\]|\*\s*[^*]{1,40}\*"
+    r"|no speech)[.!\s]*$",
+    re.IGNORECASE)
+
+
 def echoes_instruction(transcript: str, instruction: str, n: int = 5) -> bool:
     """True when the model's transcript line is an echo of the turn's own
     instruction text rather than the user's words — e.g. a flush turn's
@@ -346,10 +358,15 @@ def echoes_instruction(transcript: str, instruction: str, n: int = 5) -> bool:
     which the client would display as something the user said. Any run of
     n consecutive transcript words appearing verbatim in the instruction
     is an echo; genuine speech doesn't reproduce 5-word runs of prompt
-    text, and shorter overlaps ('what you see') are common English."""
+    text, and shorter overlaps ('what you see') are common English.
+    Double-quoted spans are stripped from the instruction first: a prompt
+    quotes phrases the user is EXPECTED to say (the translate prompt's
+    exit examples like "go back to normal conversation"), and a genuine
+    utterance reproducing one must not read as an echo."""
     words = _norm_words(transcript)
     if len(words) < n:
         return False
+    instruction = re.sub(r'"[^"]*"', " ", instruction)
     haystack = " " + " ".join(_norm_words(instruction)) + " "
     return any(" " + " ".join(words[i:i + n]) + " " in haystack
                for i in range(len(words) - n + 1))
@@ -369,14 +386,20 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
                    control_tags: tuple[str, ...] = (),
                    tts_voice: str = "af_heart",
                    proactive: bool = False,
-                   fallback: str | None = None) -> tuple[str, list, int | None]:
+                   fallback: str | None = None
+                   ) -> tuple[str, list, int | None, bool]:
     """Stream one model turn: decode → sentences → TTS, all pipelined. The
     transcript line is pushed to the client the moment it completes, while
-    the response is still decoding. Returns the raw generated text (stored
-    verbatim in history so the next request gets a full prefix-cache hit),
-    any control tags the model emitted — empty if interrupted, so an
-    aborted turn never fires an action — and the request's real prompt
-    token count when llama-server reported one (drives history rotation).
+    the response is still decoding. Returns the raw generated text, any
+    control tags the model emitted — empty if interrupted, so an aborted
+    turn never fires an action — the request's real prompt token count
+    when llama-server reported one (drives history rotation), and
+    no_speech: True when the model wrote a transcript line that had to be
+    rejected (a no-speech annotation, or an echo of the instruction) — no
+    user words stand behind this turn, so the caller must not store it or
+    act on its tags. A turn that merely OMITS the transcript marker is
+    not no_speech: real words were heard and answered, only the format
+    slipped.
 
     proactive marks a server-initiated turn (delegation delivery): the
     model's transcript line is its own echo, not the user's words, so no
@@ -438,8 +461,15 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
 
     def clean_transcript(text: str | None) -> str | None:
         """The client shows this as the user's words — never instruction
-        text the model echoed (a live flush-turn bug on real mics)."""
-        if text and echoes_instruction(text, instruction):
+        text the model echoed (a live flush-turn bug on real mics), and
+        never a non-speech annotation ('(no speech)', '[Silence]'): that
+        is the model reporting there were no words to transcribe."""
+        if not text:
+            return None
+        if NO_SPEECH_RE.match(text):
+            print(f"Transcript is a no-speech report: {text!r}")
+            return None
+        if echoes_instruction(text, instruction):
             print(f"Transcript suppressed (instruction echo): {text!r}")
             return None
         return text
@@ -447,6 +477,20 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
     async def dispatch(sentences: list[str]):
         nonlocal tts_started_at
         for sentence in sentences:
+            # A sentence that reproduces a run of the turn's own instruction
+            # is the model echoing its prompt, not speech — observed live as
+            # 'CRIPT: Begin your reply with one line:' read aloud after a
+            # degenerate transcript loop was cut mid-tag. Never on proactive
+            # turns (the delivery prompt embeds the answer being relayed),
+            # and at n=6 so short quoted phrases the user may legitimately
+            # trigger ('go back to normal conversation') still speak.
+            # Suppression is TTS/display-only: the sentence stays in the
+            # raw text, so a mixed turn (real transcript + one echoed
+            # sentence) stores the echo — an all-echo turn is dropped
+            # wholesale via no_speech, which is the poisoning case.
+            if not proactive and echoes_instruction(sentence, instruction, n=6):
+                print(f"Sentence suppressed (instruction echo): {sentence!r}")
+                continue
             if tts_started_at is None:
                 tts_started_at = time.time()
             await send_json(ws, {"type": "text_delta", "text": sentence + " "})
@@ -508,12 +552,16 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
         f"heard: {transcript!r} → {parser.response.strip()!r}"
     )
 
+    def turn_no_speech() -> bool:
+        return (not proactive and parser.transcript is not None
+                and clean_transcript(parser.transcript) is None)
+
     if interrupted.is_set():
         print("Interrupted mid-turn")
         # An aborted turn fires nothing, so its stored text must not carry
         # a tag either — the model must not believe it already delegated.
         text = parser._filter.strip(raw["text"]) if parser._filter else raw["text"]
-        return text, [], stream.prompt_tokens
+        return text, [], stream.prompt_tokens, turn_no_speech()
 
     await send_json(ws, {
         "type": "turn_final",
@@ -526,7 +574,7 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
     if audio_state["started"]:
         await send_json(ws, {"type": "audio_end",
                              "tts_time": timings.get("tts_time", 0)})
-    return raw["text"], parser.tags, stream.prompt_tokens
+    return raw["text"], parser.tags, stream.prompt_tokens, turn_no_speech()
 
 
 async def prime_cache(messages: list) -> None:

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -369,13 +369,14 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
                    control_tags: tuple[str, ...] = (),
                    tts_voice: str = "af_heart",
                    proactive: bool = False,
-                   fallback: str | None = None) -> tuple[str, list]:
+                   fallback: str | None = None) -> tuple[str, list, int | None]:
     """Stream one model turn: decode → sentences → TTS, all pipelined. The
     transcript line is pushed to the client the moment it completes, while
     the response is still decoding. Returns the raw generated text (stored
-    verbatim in history so the next request gets a full prefix-cache hit)
-    and any control tags the model emitted — empty if interrupted, so an
-    aborted turn never fires an action.
+    verbatim in history so the next request gets a full prefix-cache hit),
+    any control tags the model emitted — empty if interrupted, so an
+    aborted turn never fires an action — and the request's real prompt
+    token count when llama-server reported one (drives history rotation).
 
     proactive marks a server-initiated turn (delegation delivery): the
     model's transcript line is its own echo, not the user's words, so no
@@ -512,7 +513,7 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
         # An aborted turn fires nothing, so its stored text must not carry
         # a tag either — the model must not believe it already delegated.
         text = parser._filter.strip(raw["text"]) if parser._filter else raw["text"]
-        return text, []
+        return text, [], stream.prompt_tokens
 
     await send_json(ws, {
         "type": "turn_final",
@@ -525,7 +526,7 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
     if audio_state["started"]:
         await send_json(ws, {"type": "audio_end",
                              "tts_time": timings.get("tts_time", 0)})
-    return raw["text"], parser.tags
+    return raw["text"], parser.tags, stream.prompt_tokens
 
 
 async def prime_cache(messages: list) -> None:

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -142,6 +142,13 @@ class TagFilter:
         self._re = re.compile(
             rf"<\s*(?P<name>{alt})\s*>\s*(?P<value>.*?)\s*<\s*/\s*(?P=name)\s*>",
             re.IGNORECASE | re.DOTALL)
+        # An element left unclosed at end of stream (see finalize), and
+        # the same shape anywhere-to-end-of-text (for strip).
+        self._unclosed_re = re.compile(
+            rf"^<\s*(?P<name>{alt})\s*>\s*(?P<value>\S.*?)\s*$",
+            re.IGNORECASE | re.DOTALL)
+        self._tail_open_re = re.compile(rf"<\s*(?:{alt})\s*>.*$",
+                                        re.IGNORECASE | re.DOTALL)
         # A complete opening bracket: the element is committed, hold until
         # its close tag (or end of stream) decides it.
         self._open_re = re.compile(rf"^<\s*(?:{alt})\s*>", re.IGNORECASE)
@@ -189,10 +196,26 @@ class TagFilter:
             buf = buf[lt + 1:]
         return "".join(out)
 
+    def finalize(self) -> None:
+        """End of stream. An element still open here is the model hitting
+        EOS before the close tag — measured live, a third of exit-command
+        '<mode>conversation' switches end exactly like that. The value is
+        as complete as it will ever be, so extract it (still never
+        spoken). A mid-stream half value can never fire — this only runs
+        when no more text is coming — and the residual truncation risk is
+        benign: an incomplete mode value no-ops, a delegation task has
+        the cap/clamp guards."""
+        m = self._unclosed_re.match(self._held)
+        if m and not self._dead:
+            self.tags.append((m.group("name").upper(), m.group("value").strip()))
+        self._held = ""
+
     def strip(self, text: str) -> str:
-        """Remove complete control elements from `text` (for storing an
-        interrupted turn: history must not claim an action fired)."""
-        return self._re.sub("", text)
+        """Remove control elements, closed or unclosed-at-end, from `text`
+        (for storing an interrupted turn: history must not claim an action
+        fired). After closed elements are gone, any remaining open tag runs
+        to the end of the text by construction."""
+        return self._tail_open_re.sub("", self._re.sub("", text))
 
 
 class StreamParser:
@@ -296,6 +319,8 @@ class StreamParser:
             else:
                 self.response = self._release(self._buf)
             self._awaiting = False
+        if self._filter:
+            self._filter.finalize()  # an element left open at EOS still fires
         sentences = self._complete_sentences()
         # Cut any imitated tag markup — never speak it.
         tail = re.split(r"#{2,}", self.response[self._emitted:])[0].strip()

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -305,14 +305,16 @@ class StreamParser:
 # ── turn execution ────────────────────────────────────────────────────────
 
 # Spoken when a turn produced a control tag but no speech at all — an
-# action must never feel like the assistant ignored the user.
-TAG_ACK = "On it — I'll have that for you in a moment."
+# action must never feel like the assistant ignored the user. Generic on
+# purpose: it stands in for a delegation ack or a mode-switch confirmation.
+TAG_ACK = "Okay — one moment."
 
 
 async def run_turn(ws, messages: list, interrupted: asyncio.Event,
                    active: dict, tts_backend, expect_transcript: bool = True,
                    p_complete: float | None = None,
                    control_tags: tuple[str, ...] = (),
+                   tts_voice: str = "af_heart",
                    proactive: bool = False,
                    fallback: str | None = None) -> tuple[str, list]:
     """Stream one model turn: decode → sentences → TTS, all pipelined. The
@@ -357,7 +359,8 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
                 return
             if interrupted.is_set():
                 continue  # keep draining
-            pcm = await loop.run_in_executor(None, lambda s=sentence: tts_backend.generate(s))
+            pcm = await loop.run_in_executor(
+                None, lambda s=sentence: tts_backend.generate(s, voice=tts_voice))
             if interrupted.is_set():
                 continue
             if not audio_state["started"]:
@@ -416,7 +419,9 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
             # a control tag. Neither may end in silence — speak the ack or
             # the caller's fallback, and keep history coherent with what was
             # actually said.
-            say = TAG_ACK if parser.tags else fallback
+            # A proactive (delivery) turn always prefers its fallback: it IS
+            # the answer, and a stray tag must not replace it with an ack.
+            say = fallback if proactive else (TAG_ACK if parser.tags else fallback)
             if tts_started_at is None and say:
                 raw["text"] += "\n" + say
                 await dispatch([say])

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -310,6 +310,34 @@ class StreamParser:
 TAG_ACK = "Okay — one moment."
 
 
+def _norm_words(text: str) -> list[str]:
+    return re.sub(r"[^a-z0-9' ]+", " ", text.lower()).split()
+
+
+def echoes_instruction(transcript: str, instruction: str, n: int = 5) -> bool:
+    """True when the model's transcript line is an echo of the turn's own
+    instruction text rather than the user's words — e.g. a flush turn's
+    '###TRANSCRIPT: The user paused mid-thought, so on a new line: …',
+    which the client would display as something the user said. Any run of
+    n consecutive transcript words appearing verbatim in the instruction
+    is an echo; genuine speech doesn't reproduce 5-word runs of prompt
+    text, and shorter overlaps ('what you see') are common English."""
+    words = _norm_words(transcript)
+    if len(words) < n:
+        return False
+    haystack = " " + " ".join(_norm_words(instruction)) + " "
+    return any(" " + " ".join(words[i:i + n]) + " " in haystack
+               for i in range(len(words) - n + 1))
+
+
+def _instruction_text(messages: list) -> str:
+    content = messages[-1].get("content", "")
+    if isinstance(content, str):
+        return content
+    return " ".join(p.get("text", "") for p in content
+                    if isinstance(p, dict) and p.get("type") == "text")
+
+
 async def run_turn(ws, messages: list, interrupted: asyncio.Event,
                    active: dict, tts_backend, expect_transcript: bool = True,
                    p_complete: float | None = None,
@@ -380,6 +408,15 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
     parser = StreamParser(expect_transcript, control_tags)
     tts_started_at = None
     transcript_sent = False
+    instruction = _instruction_text(messages)
+
+    def clean_transcript(text: str | None) -> str | None:
+        """The client shows this as the user's words — never instruction
+        text the model echoed (a live flush-turn bug on real mics)."""
+        if text and echoes_instruction(text, instruction):
+            print(f"Transcript suppressed (instruction echo): {text!r}")
+            return None
+        return text
 
     async def dispatch(sentences: list[str]):
         nonlocal tts_started_at
@@ -403,9 +440,10 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
                 if parser.transcript and not transcript_sent:
                     transcript_sent = True
                     timings["transcript_s"] = round(time.time() - t0, 3)
-                    if not proactive:
+                    shown = clean_transcript(parser.transcript)
+                    if shown and not proactive:
                         await send_json(ws, {"type": "transcript",
-                                             "transcription": parser.transcript,
+                                             "transcription": shown,
                                              "p_complete": p_complete})
 
         tail, transcript = parser.finalize()
@@ -453,7 +491,7 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
 
     await send_json(ws, {
         "type": "turn_final",
-        "transcription": None if proactive else transcript,
+        "transcription": None if proactive else clean_transcript(transcript),
         "proactive": proactive,
         "timings": timings,
         "p_complete": p_complete,

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -121,31 +121,45 @@ async def release_client(ws) -> None:
 
 class TagFilter:
     """Streams response text through, extracting complete
-    '<name>value</name>' control elements into .tags and holding back any
-    suffix that may still become one. XML elements (not ###NAME: lines)
-    because the model emits them more reliably — benchmarks/tagbench.py
-    measured recall 0.667 vs 0.417 on E4B — and the explicit close tag
-    means a tag completes mid-stream and a half-streamed value can never
-    be extracted. Held text is released only once it turns out not to be
-    an element, so markup still open when the stream ends is never spoken
-    and never fires: a delegation with half its task is worse than none."""
+    '<name>value</name>' control elements into .tags. XML elements (not
+    ###NAME: lines) because the model emits them more reliably —
+    benchmarks/tagbench.py measured recall 0.667 vs 0.417 on E4B — and
+    the explicit close tag means a half-streamed value can never fire.
+
+    Parsed tolerantly ('< delegate >x</delegate>' extracts — firing the
+    intended action beats suppressing it) and the value may contain '<'
+    ('flights under <$500'); only the close tag terminates it. Anything
+    that names a control tag without being a clean element (a stray
+    '</delegate>', '<delegate x=1>') suppresses all further speech,
+    mirroring the ##-markup rule: it is model error, and speaking it —
+    task text included — is the worst outcome. Ordinary prose '<'
+    ('5 < 10') passes through. Markup still open when the stream ends is
+    dropped, never spoken and never fired: a delegation with half its
+    task is worse than none."""
 
     def __init__(self, names: tuple[str, ...]):
-        self._opens = [f"<{n.lower()}>" for n in names]
+        alt = "|".join(names)  # names are plain lowercase words
         self._re = re.compile(
-            r"<(?P<name>" + "|".join(names) + r")>\s*(?P<value>[^<]*?)\s*"
-            r"</(?P=name)>", re.IGNORECASE)
+            rf"<\s*(?P<name>{alt})\s*>\s*(?P<value>.*?)\s*<\s*/\s*(?P=name)\s*>",
+            re.IGNORECASE | re.DOTALL)
+        # A complete opening bracket: the element is committed, hold until
+        # its close tag (or end of stream) decides it.
+        self._open_re = re.compile(rf"^<\s*(?:{alt})\s*>", re.IGNORECASE)
+        # Names a control tag (with optional '/' and spacing) — but only
+        # consulted after _re and _open_re failed, so it is a near-miss.
+        self._miss_re = re.compile(rf"^<\s*/?\s*(?:{alt})\b", re.IGNORECASE)
+        # Too short to judge: '<', '</', '< dele' — letters (a name prefix)
+        # possibly followed by whitespace, still awaiting a decisive char.
+        self._forming_re = re.compile(r"^<[\s/]*([a-zA-Z]*)\s*$")
+        self._names = [n.lower() for n in names]
         self._held = ""
+        self._dead = False
         self.tags: list[tuple[str, str]] = []  # (NAME, value), stream order
-
-    def _viable(self, rest: str) -> bool:
-        """Could `rest` (starting at '<') still grow into, or already be
-        inside, a control element?"""
-        rest = rest.lower()
-        return any(o.startswith(rest) or rest.startswith(o) for o in self._opens)
 
     def feed(self, delta: str) -> str:
         """Returns the speakable text released by this delta."""
+        if self._dead:
+            return ""
         buf = self._held + delta
         self._held = ""
         out = []
@@ -160,12 +174,19 @@ class TagFilter:
                 self.tags.append((m.group("name").upper(), m.group("value").strip()))
                 out.append("\n")  # keep a boundary where the element sat
                 buf = buf[m.end():]
-            elif self._viable(buf[lt:]):
-                self._held = buf[lt:]
+                continue
+            rest = buf[lt:]
+            forming = self._forming_re.match(rest)
+            if self._open_re.match(rest) or (
+                    forming and any(n.startswith(forming.group(1).lower())
+                                    for n in self._names)):
+                self._held = rest  # a clean element may still complete
                 break
-            else:
-                out.append("<")  # literal '<', not ours
-                buf = buf[lt + 1:]
+            if self._miss_re.match(rest):
+                self._dead = True  # markup, not speech — nothing more is spoken
+                break
+            out.append("<")  # literal '<', not ours
+            buf = buf[lt + 1:]
         return "".join(out)
 
 

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -119,6 +119,56 @@ async def release_client(ws) -> None:
 
 # ── streaming turn parser ─────────────────────────────────────────────────
 
+class TagFilter:
+    """Streams response text through, extracting complete
+    '<name>value</name>' control elements into .tags and holding back any
+    suffix that may still become one. XML elements (not ###NAME: lines)
+    because the model emits them more reliably — benchmarks/tagbench.py
+    measured recall 0.667 vs 0.417 on E4B — and the explicit close tag
+    means a tag completes mid-stream and a half-streamed value can never
+    be extracted. Held text is released only once it turns out not to be
+    an element, so markup still open when the stream ends is never spoken
+    and never fires: a delegation with half its task is worse than none."""
+
+    def __init__(self, names: tuple[str, ...]):
+        self._opens = [f"<{n.lower()}>" for n in names]
+        self._re = re.compile(
+            r"<(?P<name>" + "|".join(names) + r")>\s*(?P<value>[^<]*?)\s*"
+            r"</(?P=name)>", re.IGNORECASE)
+        self._held = ""
+        self.tags: list[tuple[str, str]] = []  # (NAME, value), stream order
+
+    def _viable(self, rest: str) -> bool:
+        """Could `rest` (starting at '<') still grow into, or already be
+        inside, a control element?"""
+        rest = rest.lower()
+        return any(o.startswith(rest) or rest.startswith(o) for o in self._opens)
+
+    def feed(self, delta: str) -> str:
+        """Returns the speakable text released by this delta."""
+        buf = self._held + delta
+        self._held = ""
+        out = []
+        while buf:
+            lt = buf.find("<")
+            if lt == -1:
+                out.append(buf)
+                break
+            out.append(buf[:lt])
+            m = self._re.match(buf, lt)
+            if m:
+                self.tags.append((m.group("name").upper(), m.group("value").strip()))
+                out.append("\n")  # keep a boundary where the element sat
+                buf = buf[m.end():]
+            elif self._viable(buf[lt:]):
+                self._held = buf[lt:]
+                break
+            else:
+                out.append("<")  # literal '<', not ours
+                buf = buf[lt + 1:]
+        return "".join(out)
+
+
 class StreamParser:
     """Incrementally parses '###TRANSCRIPT: <words>\\n<response>'.
 
@@ -133,16 +183,32 @@ class StreamParser:
     partial sentence and the transcript. With expect_transcript=False
     (text/image turns) the reply streams directly and any imitated
     trailing tag is cut, never spoken.
+
+    control_tags names '<name>value</name>' elements the model may emit
+    as actions (e.g. delegate, mode). A recognized element is excised by
+    a TagFilter — appended to self.tags, never spoken — and speech
+    resumes after it; '##…' markup keeps the terminal cut above.
     """
 
-    def __init__(self, expect_transcript: bool = True):
+    def __init__(self, expect_transcript: bool = True,
+                 control_tags: tuple[str, ...] = ()):
         self.response = ""
         self.transcript: str | None = None
+        self._filter = TagFilter(control_tags) if control_tags else None
         self._awaiting = expect_transcript
         self._got_tag = False
         self._buf = ""
         self._before_tag = ""  # stray text before the tag → response prefix
         self._emitted = 0
+
+    @property
+    def tags(self) -> list[tuple[str, str]]:
+        return self._filter.tags if self._filter else []
+
+    def _release(self, text: str) -> str:
+        """Response text passes through the control-tag filter (if any)
+        before it can be spoken."""
+        return self._filter.feed(text) if self._filter else text
 
     def feed(self, delta: str) -> list[str]:
         if self._awaiting:
@@ -165,11 +231,12 @@ class StreamParser:
                 m = SENTENCE_END_RE.search(self._buf)
                 newline = m.end() - 1 if m else len(self._buf) - 1
             self.transcript = self._buf[:newline].strip() or None
-            self.response = (self._before_tag + self._buf[newline + 1:]).lstrip()
+            self.response = self._release(
+                (self._before_tag + self._buf[newline + 1:]).lstrip())
             self._awaiting = False
             self._buf = ""
         else:
-            self.response += delta
+            self.response += self._release(delta)
         return self._complete_sentences()
 
     def _complete_sentences(self) -> list[str]:
@@ -199,9 +266,9 @@ class StreamParser:
                 m = SENTENCE_END_RE.search(self._buf)
                 cut = m.end() if m else len(self._buf)
                 self.transcript = self._buf[:cut].strip() or None
-                self.response = self._before_tag + self._buf[cut:]
+                self.response = self._release(self._before_tag + self._buf[cut:])
             else:
-                self.response = self._buf
+                self.response = self._release(self._buf)
             self._awaiting = False
         sentences = self._complete_sentences()
         # Cut any imitated tag markup — never speak it.

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -189,6 +189,11 @@ class TagFilter:
             buf = buf[lt + 1:]
         return "".join(out)
 
+    def strip(self, text: str) -> str:
+        """Remove complete control elements from `text` (for storing an
+        interrupted turn: history must not claim an action fired)."""
+        return self._re.sub("", text)
+
 
 class StreamParser:
     """Incrementally parses '###TRANSCRIPT: <words>\\n<response>'.
@@ -299,14 +304,28 @@ class StreamParser:
 
 # ── turn execution ────────────────────────────────────────────────────────
 
+# Spoken when a turn produced a control tag but no speech at all — an
+# action must never feel like the assistant ignored the user.
+TAG_ACK = "On it — I'll have that for you in a moment."
+
+
 async def run_turn(ws, messages: list, interrupted: asyncio.Event,
                    active: dict, tts_backend, expect_transcript: bool = True,
                    p_complete: float | None = None,
-                   fallback: str | None = None) -> str:
+                   control_tags: tuple[str, ...] = (),
+                   proactive: bool = False,
+                   fallback: str | None = None) -> tuple[str, list]:
     """Stream one model turn: decode → sentences → TTS, all pipelined. The
     transcript line is pushed to the client the moment it completes, while
     the response is still decoding. Returns the raw generated text (stored
-    verbatim in history so the next request gets a full prefix-cache hit)."""
+    verbatim in history so the next request gets a full prefix-cache hit)
+    and any control tags the model emitted — empty if interrupted, so an
+    aborted turn never fires an action.
+
+    proactive marks a server-initiated turn (delegation delivery): the
+    model's transcript line is its own echo, not the user's words, so no
+    transcript frame is sent and turn_final carries proactive=True — the
+    client must never fill a user bubble from it."""
     loop = asyncio.get_event_loop()
     t0 = time.time()
     timings: dict = {}
@@ -355,7 +374,7 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
             audio_state["chunks"] += 1
 
     tts_task = asyncio.create_task(tts_worker())
-    parser = StreamParser(expect_transcript)
+    parser = StreamParser(expect_transcript, control_tags)
     tts_started_at = None
     transcript_sent = False
 
@@ -381,9 +400,10 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
                 if parser.transcript and not transcript_sent:
                     transcript_sent = True
                     timings["transcript_s"] = round(time.time() - t0, 3)
-                    await send_json(ws, {"type": "transcript",
-                                         "transcription": parser.transcript,
-                                         "p_complete": p_complete})
+                    if not proactive:
+                        await send_json(ws, {"type": "transcript",
+                                             "transcription": parser.transcript,
+                                             "p_complete": p_complete})
 
         tail, transcript = parser.finalize()
         timings["llm_time"] = round(time.time() - t0, 3)
@@ -391,13 +411,15 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
 
         if not interrupted.is_set():
             await dispatch(tail)
-            if fallback and tts_started_at is None:
-                # The model emitted only a transcript line (models of every
-                # size sometimes do this for cut-off audio) — a flush turn
-                # must never end in silence, so speak the fallback and keep
-                # history coherent with what was actually said.
-                raw["text"] += "\n" + fallback
-                await dispatch([fallback])
+            # A turn may still end with nothing spoken: only a transcript
+            # line (models of every size do this for cut-off audio), or only
+            # a control tag. Neither may end in silence — speak the ack or
+            # the caller's fallback, and keep history coherent with what was
+            # actually said.
+            say = TAG_ACK if parser.tags else fallback
+            if tts_started_at is None and say:
+                raw["text"] += "\n" + say
+                await dispatch([say])
     finally:
         active["stream"] = None
         sentence_q.put_nowait(_DONE)
@@ -419,11 +441,15 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
 
     if interrupted.is_set():
         print("Interrupted mid-turn")
-        return raw["text"]
+        # An aborted turn fires nothing, so its stored text must not carry
+        # a tag either — the model must not believe it already delegated.
+        text = parser._filter.strip(raw["text"]) if parser._filter else raw["text"]
+        return text, []
 
     await send_json(ws, {
         "type": "turn_final",
-        "transcription": transcript,
+        "transcription": None if proactive else transcript,
+        "proactive": proactive,
         "timings": timings,
         "p_complete": p_complete,
         "spoke": audio_state["started"],  # False → client must not wait for audio_end
@@ -431,7 +457,7 @@ async def run_turn(ws, messages: list, interrupted: asyncio.Event,
     if audio_state["started"]:
         await send_json(ws, {"type": "audio_end",
                              "tts_time": timings.get("tts_time", 0)})
-    return raw["text"]
+    return raw["text"], parser.tags
 
 
 async def prime_cache(messages: list) -> None:

--- a/src/reasoner.py
+++ b/src/reasoner.py
@@ -1,0 +1,68 @@
+"""Background reasoner: hands a task from the voice model to a frontier
+text model on any OpenAI-compatible chat endpoint and returns a short
+speakable answer.
+
+Disabled unless REASONER_API_KEY is set — without it the delegation
+instruction is simply absent from the system prompt and Parlor stays
+fully on-device. Defaults to OpenRouter, where REASONER_WEB_SEARCH=1
+(the default) appends the ':online' suffix so any model gets
+provider-side web search; other endpoints (a direct provider URL, a
+second local llama-server) ignore the flag.
+"""
+
+import json
+import os
+import urllib.request
+
+BASE_URL = os.environ.get("REASONER_BASE_URL",
+                          "https://openrouter.ai/api/v1").rstrip("/")
+API_KEY = os.environ.get("REASONER_API_KEY", "")
+MODEL = os.environ.get("REASONER_MODEL", "anthropic/claude-sonnet-4.5")
+try:
+    TIMEOUT_S = float(os.environ.get("REASONER_TIMEOUT", "90"))
+except ValueError:
+    print("REASONER_TIMEOUT is not a number — using 90s")
+    TIMEOUT_S = 90.0
+
+# On OpenRouter web search is requested through the model id itself, so it
+# has to be baked in here; other endpoints would reject the suffix.
+if (os.environ.get("REASONER_WEB_SEARCH", "1") == "1"
+        and "openrouter.ai" in BASE_URL and not MODEL.endswith(":online")):
+    MODEL += ":online"
+
+# The answer is relayed aloud by the voice model near-verbatim, so it must
+# already be speech-shaped when it comes back.
+SYSTEM_PROMPT = (
+    "You are the background research assistant behind a real-time voice "
+    "AI. Answer the task directly, in plain conversational text that will "
+    "be read aloud: no markdown, no lists, no headings, no URLs. Lead "
+    "with the answer, keep it to 2-6 short sentences, and include the "
+    "concrete facts (names, numbers, places) the task asks for."
+)
+
+
+def enabled() -> bool:
+    return bool(API_KEY)
+
+
+def ask(task: str) -> str:
+    """Blocking chat-completion call — run it in an executor. Raises on
+    transport/HTTP errors and empty answers; the caller turns any failure
+    into a spoken apology."""
+    req = urllib.request.Request(
+        BASE_URL + "/chat/completions",
+        data=json.dumps({
+            "model": MODEL,
+            "messages": [{"role": "system", "content": SYSTEM_PROMPT},
+                         {"role": "user", "content": task}],
+            "max_tokens": 1024,  # the answer is spoken aloud — cap essays
+        }).encode(),
+        headers={"Content-Type": "application/json",
+                 "Authorization": f"Bearer {API_KEY}"},
+    )
+    with urllib.request.urlopen(req, timeout=TIMEOUT_S) as resp:
+        body = json.load(resp)
+    answer = (body["choices"][0]["message"]["content"] or "").strip()
+    if not answer:
+        raise RuntimeError("reasoner returned an empty answer")
+    return answer

--- a/src/server.py
+++ b/src/server.py
@@ -94,7 +94,7 @@ MODE_SUFFIX = (
 # session) must be spelled out where the translating happens.
 TRANSLATE_PROMPT = (
     "Live translation mode. Begin your reply with one line: ###TRANSCRIPT: "
-    "followed by the exact words the user said in their audio message, in "
+    "followed by the exact words the user said in this message's audio, in "
     "their original language. Then, on a new line, write ONLY the English "
     "translation of those words — no commentary, no answers, no opinions. "
     "If they already spoke English, restate their words in clear English. "
@@ -102,7 +102,8 @@ TRANSLATE_PROMPT = (
     "translation — like \"stop translating\", \"go back to normal "
     "conversation\", \"berhenti menerjemahkan\", \"deja de traducir\" — do "
     "NOT translate it: confirm in one short sentence and end with "
-    "<mode>conversation</mode>."
+    "<mode>conversation</mode>. If the audio has no clear words, write "
+    "###TRANSCRIPT: (no speech) and nothing else."
 )
 
 # A finished background task is delivered by the voice model, not read out
@@ -158,9 +159,25 @@ def strip_unfired_tags(text: str, tags: list) -> str:
 # long utterances) before first audio — measured worth it. Grammar-forced
 # JSON ({transcript, response}) was also measured: format breaks 1-3/3 on
 # degraded audio and 3/3 on chunked — don't go back to structured output.
+# The no-speech clause gives the model a sanctioned out for VAD false
+# triggers (breath, cough, room noise). Without it the prompt DEMANDS
+# words, so on speechless audio the model invents some — measured at
+# temp 0.7: a breath came back as "Hi, can you help me with my homework?"
+# (answered), "can you translate everything I say from now on?" (mode
+# switched!), or an earlier turn's question copied verbatim. "this
+# message's audio" (not "their audio message") points the transcription
+# at the newest clip among the many in history; measured clean with this
+# wording at temp 0 and 0.7 (WER 0.0 on speech, fresh and late).
+NO_SPEECH_CLAUSE = (
+    " If the audio has no clear words — noise, breathing, silence — write "
+    "###TRANSCRIPT: (no speech) instead; never guess words or repeat "
+    "earlier ones."
+)
+
 RESPOND_PROMPT = (
     "Begin your reply with one line: ###TRANSCRIPT: followed by the exact "
-    "words the user said in their audio message. Then, on a new line, respond "
+    "words the user said in this message's audio." + NO_SPEECH_CLAUSE +
+    " Then, on a new line, respond "
     "to them: 1-4 short sentences, spoken aloud.{camera}"
 )
 
@@ -178,7 +195,8 @@ AUDIO_FALLBACK = "Sorry, I didn't catch that — could you say it again?"
 # stop, leaving the turn silent.
 FLUSH_PROMPT = (
     "Begin your reply with one line: ###TRANSCRIPT: followed by the exact "
-    "words the user said in their audio message. The user paused mid-thought, "
+    "words the user said in this message's audio." + NO_SPEECH_CLAUSE +
+    " The user paused mid-thought, "
     "so on a new line: if their words feel unfinished, write one short, warm "
     "sentence encouraging them to continue; otherwise respond to them in 1-4 "
     "short sentences, spoken aloud.{camera}"
@@ -186,7 +204,26 @@ FLUSH_PROMPT = (
 
 # Rotate history before the llama context fills. Rough token estimates are
 # fine here — the guard just needs to fire before generation degrades.
-CONTEXT_HEADROOM = 2000
+# Scaled to the context size: a fixed 2000 against the suite's small
+# LLAMA_CTX left a near-zero threshold, rotating on every turn — history
+# never accumulated, so the e2e suite silently stopped exercising
+# multi-turn context at all.
+CONTEXT_HEADROOM = max(512, min(2000, llama.CTX // 8))
+
+
+def rotate_history(history: list) -> list:
+    """Drop the oldest quarter of messages, keeping the system prompt. The
+    kept slice must start on a user message: dropping a user turn while
+    keeping its reply would leave an orphaned assistant message about
+    words that no longer exist. A history with at most one exchange
+    returns unchanged (nothing droppable — and slicing a bare [system]
+    would duplicate the system prompt)."""
+    if len(history) <= 3:
+        return history
+    keep = 1 + max(2, 3 * (len(history) - 1) // 4)
+    while keep > 3 and history[-(keep - 1)].get("role") != "user":
+        keep -= 1
+    return [history[0]] + history[-(keep - 1):]
 
 tts_backend = None
 detector = None  # smart-turn end-of-turn classifier
@@ -270,13 +307,23 @@ async def websocket_endpoint(ws: WebSocket):
     speech_chunks: list[str] = []    # streamed-in speech, already cache-primed
     held_audio: list[str] = []       # incomplete-turn segments awaiting continuation
 
-    def remember(user_msg: dict, raw_text: str) -> None:
-        """Store a finished turn verbatim (same bytes → full prefix-cache hit
-        on the next request). A turn the model produced nothing for is never
-        stored — a degenerate message poisons all later requests."""
-        if raw_text.strip():
-            history.append(user_msg)
-            history.append({"role": "assistant", "content": raw_text})
+    def remember(user_msg: dict, raw_text: str, no_speech: bool) -> None:
+        """Store a finished turn verbatim (same bytes → full prefix-cache
+        hit on the next request). Two kinds of turn are never stored,
+        because a degenerate message poisons every later request: one the
+        model produced nothing for, and a no_speech turn (the transcript
+        line was a no-speech annotation or an instruction echo — no user
+        words stand behind it; one stored echo loop came back as invented
+        or copied user words on every turn after it). Voice turns must
+        keep their raw audio: an experiment storing the transcript as
+        user text instead made the model copy the PREVIOUS turn's text as
+        the new turn's transcript, deterministically at temp 0 —
+        user-role text reads as 'what the user said' more strongly than
+        the current audio does."""
+        if not raw_text.strip() or no_speech:
+            return
+        history.append(user_msg)
+        history.append({"role": "assistant", "content": raw_text})
 
     delegation_ids = itertools.count(1)
     delegation_tasks: set[asyncio.Task] = set()
@@ -400,26 +447,26 @@ async def websocket_endpoint(ws: WebSocket):
         prompt = (DELIVER_PROMPT if done["ok"] else DELIVER_FAILED_PROMPT).format(
             task=done["task"], answer=done["answer"])
         user_msg = {"role": "user", "content": [text_part(prompt)]}
-        # expect_transcript=True although there is no audio: history trains
-        # the model to open every reply with ###TRANSCRIPT:, and it often
-        # does so here too (echoing the instruction). The transcript parser
-        # consumes that line and streams the real delivery; with False the
-        # ##-markup cut would swallow the entire reply (observed live).
-        raw_text, tags, pt = await run_turn(ws, history + [user_msg], interrupted,
-                                            active, tts_backend,
-                                            expect_transcript=True,
-                                            control_tags=CONTROL_TAGS,
-                                            tts_voice=mode.tts_voice,
-                                            proactive=True,
-                                            fallback=done["answer"] if done["ok"]
-                                            else DELIVER_FALLBACK)
+        # expect_transcript=True although there is no audio: the model
+        # often opens a delivery with an imitated ###TRANSCRIPT: line, and
+        # the transcript parser consumes it and streams the real delivery;
+        # with False the ##-markup cut would swallow the entire reply
+        # (observed live).
+        raw_text, tags, pt, _ = await run_turn(ws, history + [user_msg], interrupted,
+                                               active, tts_backend,
+                                               expect_transcript=True,
+                                               control_tags=CONTROL_TAGS,
+                                               tts_voice=mode.tts_voice,
+                                               proactive=True,
+                                               fallback=done["answer"] if done["ok"]
+                                               else DELIVER_FALLBACK)
         if pt:
             prompt_tokens["last"] = pt
         if raw_text.strip():
             playing_since["t"] = time.time()  # this delivery is now playing
         unfired = await spawn_delegations(tags)  # a delivery may chain research
         unfired += [(n, v) for n, v in tags if n == "MODE"]  # never applied here
-        remember(user_msg, strip_unfired_tags(raw_text, unfired))
+        remember(user_msg, strip_unfired_tags(raw_text, unfired), no_speech=False)
         drain_ready()                  # more results may already be waiting
 
     async def prime(audio_b64s: list[str]) -> None:
@@ -444,11 +491,12 @@ async def websocket_endpoint(ws: WebSocket):
             est = estimate_tokens(history)
             used = max(est, prompt_tokens["last"])
             if used > llama.CTX - 2 * CONTEXT_HEADROOM:
-                keep = 1 + max(2, 3 * (len(history) - 1) // 4)
-                print(f"Context near limit (est {est}, real {prompt_tokens['last']}) "
-                      f"— dropping {len(history) - keep} oldest messages")
-                history = [history[0]] + history[-(keep - 1):]
-                prompt_tokens["last"] = 0  # stale after a rotation
+                rotated = rotate_history(history)
+                if len(rotated) < len(history):
+                    print(f"Context near limit (est {est}, real {prompt_tokens['last']}) "
+                          f"— dropping {len(history) - len(rotated)} oldest messages")
+                    history = rotated
+                    prompt_tokens["last"] = 0  # stale after a rotation
 
             if msg.get("type") == "ready":
                 # The client returned to idle listening: playback finished,
@@ -569,20 +617,28 @@ async def websocket_endpoint(ws: WebSocket):
                     if has_audio:
                         instruction += MODE_SUFFIX
                 user_msg = {"role": "user", "content": content + [text_part(instruction)]}
-                raw_text, tags, pt = await run_turn(ws, history + [user_msg], interrupted, active,
-                                                    tts_backend, expect_transcript=has_audio,
-                                                    p_complete=p_complete,
-                                                    control_tags=CONTROL_TAGS,
-                                                    tts_voice=mode.tts_voice,
-                                                    fallback=FLUSH_FALLBACK if is_flush
-                                                    else AUDIO_FALLBACK if has_audio else None)
+                raw_text, tags, pt, no_speech = await run_turn(
+                    ws, history + [user_msg], interrupted, active,
+                    tts_backend, expect_transcript=has_audio,
+                    p_complete=p_complete,
+                    control_tags=CONTROL_TAGS,
+                    tts_voice=mode.tts_voice,
+                    fallback=FLUSH_FALLBACK if is_flush
+                    else AUDIO_FALLBACK if has_audio else None)
                 if pt:
                     prompt_tokens["last"] = pt
                 if raw_text.strip():
                     playing_since["t"] = time.time()  # reply now playing client-side
-                unfired = await spawn_delegations(tags)
-                unfired += await apply_mode_tags(tags)
-                remember(user_msg, strip_unfired_tags(raw_text, unfired))
+                if no_speech:
+                    # No user words stand behind this turn: a control tag
+                    # born from noise must not act (measured live — a breath
+                    # transcribed as "translate everything I say" switched
+                    # the session into translate mode).
+                    unfired = tags
+                else:
+                    unfired = await spawn_delegations(tags)
+                    unfired += await apply_mode_tags(tags)
+                remember(user_msg, strip_unfired_tags(raw_text, unfired), no_speech)
             except DISCONNECT_ERRORS:
                 raise
             except Exception:

--- a/src/server.py
+++ b/src/server.py
@@ -42,6 +42,7 @@ load_dotenv()  # before importing llama — it reads its config at import time
 import llama
 import reasoner
 import tts
+from modes import MODES
 from pipeline import (estimate_tokens, pad_tail_silence, prime_cache,
                       release_client, run_turn, send_json, text_part,
                       user_content, valid_audio, wav_to_float32)
@@ -74,25 +75,62 @@ DELEGATE_INSTRUCTION = (
     "Everything else, answer yourself and don't use the tag."
 )
 
+# The mode-switch instruction lives in the per-turn prompt, not the
+# system prompt: E4B acts on the instruction adjacent to the audio (like
+# the ###TRANSCRIPT line, 6/6 in probing) and ignores the same words in
+# the system prompt entirely (0/6, even with few-shot examples) — for
+# translation it believes it already has the capability, so only the
+# always-attended slot makes it emit the switch.
+MODE_SUFFIX = (
+    " If the audio asks you to translate everything they say from now on, "
+    "confirm briefly and end with <mode>translate</mode>."
+)
+
+# The per-utterance instruction in translate mode. It carries the exit
+# path itself: in this mode every utterance is content to translate, so
+# the one exception (a command addressed to the assistant about the
+# session) must be spelled out where the translating happens.
+TRANSLATE_PROMPT = (
+    "Live translation mode. Begin your reply with one line: ###TRANSCRIPT: "
+    "followed by the exact words the user said in their audio message, in "
+    "their original language. Then, on a new line, write ONLY the English "
+    "translation of those words — no commentary, no answers, no opinions. "
+    "If they already spoke English, restate their words in clear English. "
+    "Exception: if they are clearly addressing YOU with a command to stop "
+    "or change translation (\"stop translating\", \"back to normal\"), "
+    "confirm in one short sentence and append <mode>conversation</mode>."
+)
+
 # A finished background task is delivered by the voice model, not read out
 # raw: it ties the answer back to the conversation and keeps one voice.
+# "System note (not user audio)" leads both prompts because the model
+# occasionally misread the text-only turn as its own reply playing back
+# and gave the anti-echo response instead of the answer (observed live).
 DELIVER_PROMPT = (
-    'Your background research assistant just finished the task "{task}". '
-    "Its answer:\n{answer}\n\n"
-    "Deliver this answer to the user now: tie it back to what they asked "
+    "System note (not user audio): your background research assistant "
+    'just finished the task "{task}". Its answer:\n{answer}\n\n'
+    "Tell the user this answer now: tie it back to what they asked "
     "earlier, keep every fact exactly as given, 2-5 short sentences, "
     "plain spoken text."
 )
 DELIVER_FAILED_PROMPT = (
-    'Your background research assistant could not finish the task '
-    '"{task}". Briefly tell the user you couldn\'t get that answer, and '
-    "that they're welcome to ask again. Don't start new research now."
+    "System note (not user audio): your background research assistant "
+    'could not finish the task "{task}". Briefly tell the user you '
+    "couldn't get that answer, and that they're welcome to ask again. "
+    "Don't start new research now."
 )
 DELIVER_FALLBACK = "Sorry — I couldn't get an answer for that one."
 
 # One session can only usefully consume a few pending research tasks, and
 # an off-the-rails reply must not queue an HTTP call per imagined tag.
 MAX_PENDING_DELEGATIONS = 3
+
+# The stream filter must ALWAYS know every control-tag name any prompt can
+# incite — the system prompt (with its delegate instruction) is the
+# prefix-cache prefix and survives mode switches, and a name the filter
+# doesn't know is spoken aloud, task text included. Modes gate ACTING on a
+# tag (spawn_delegations, apply_mode_tags), never parsing it.
+CONTROL_TAGS = ("delegate", "mode")
 
 # The transcript line LEADS the reply: transcribing after the response
 # turns the transcript into a paraphrase from memory (WER 0.39 vs 0.00 on a
@@ -181,8 +219,8 @@ async def websocket_endpoint(ws: WebSocket):
 
     delegation = reasoner.enabled()
     system = SYSTEM_PROMPT + (DELEGATE_INSTRUCTION if delegation else "")
-    control_tags = ("delegate",) if delegation else ()
     history: list = [{"role": "system", "content": system}]
+    mode = MODES["conversation"]
 
     interrupted = asyncio.Event()
     active = {"stream": None}
@@ -234,9 +272,40 @@ async def websocket_endpoint(ws: WebSocket):
     def drain_ready() -> None:
         """Requeue one finished delegation whenever the floor frees up —
         called at every point that releases it, because msg_queue only
-        wakes for client traffic and a result must not wait for one."""
-        if ready_delegations and not floor_busy():
+        wakes for client traffic and a result must not wait for one.
+        Results also wait out translation mode: an English research answer
+        must not barge into an interpreting session."""
+        if mode.allows_delegation and ready_delegations and not floor_busy():
             msg_queue.put_nowait(ready_delegations.pop(0))
+
+    async def switch_mode(name: str) -> None:
+        """Enter a mode by name (model tag or UI escape hatch). Unknown and
+        already-current names are no-ops, so callers can pass raw values."""
+        nonlocal mode, frame_image, speech_chunks, held_audio
+        name = name.strip().lower()
+        if name == mode.name:
+            return
+        if name not in MODES:
+            # The model confirmed something out loud and then emitted junk —
+            # make that diagnosable instead of a silent nothing.
+            print(f"Ignoring unknown mode {name!r}")
+            return
+        mode = MODES[name]
+        # Start the new mode clean: a switch through the UI escape hatch can
+        # fire with audio held under the OLD mode's gating, and translate
+        # mode never resolves holds — stale held state would keep
+        # floor_busy() true and block deliveries for the whole session.
+        frame_image = None
+        speech_chunks = []
+        held_audio = []
+        print(f"Mode → {mode.name}")
+        await send_json(ws, {"type": "mode_changed", "mode": mode.name})
+        drain_ready()  # leaving translation frees deferred deliveries
+
+    async def apply_mode_tags(tags: list[tuple[str, str]]) -> None:
+        for name, value in tags:
+            if name == "MODE":
+                await switch_mode(value)
 
     async def run_delegation(task_id: int, task: str) -> None:
         """Background reasoner call; its outcome re-enters the main loop
@@ -256,6 +325,11 @@ async def websocket_endpoint(ws: WebSocket):
                              "task": task, **outcome})
 
     async def spawn_delegations(tags: list[tuple[str, str]]) -> None:
+        if not delegation or not mode.allows_delegation:
+            # The filter still parses <delegate> here (so it is never
+            # spoken); without a reasoner, or mid-translation, it must
+            # also never fire.
+            return
         for name, value in tags:
             if name == "DELEGATE" and value.strip():
                 if len(delegation_tasks) >= MAX_PENDING_DELEGATIONS:
@@ -290,7 +364,8 @@ async def websocket_endpoint(ws: WebSocket):
         raw_text, tags = await run_turn(ws, history + [user_msg], interrupted,
                                         active, tts_backend,
                                         expect_transcript=True,
-                                        control_tags=control_tags,
+                                        control_tags=CONTROL_TAGS,
+                                        tts_voice=mode.tts_voice,
                                         proactive=True,
                                         fallback=done["answer"] if done["ok"]
                                         else DELIVER_FALLBACK)
@@ -327,9 +402,23 @@ async def websocket_endpoint(ws: WebSocket):
                 drain_ready()
                 continue
 
+            if msg.get("type") == "set_mode":
+                # The UI escape hatch (mode chip's stop button): a switch
+                # that must work even when the model mistranslates the
+                # spoken exit command.
+                await switch_mode(str(msg.get("mode", "")))
+                continue
+
             if msg.get("type") == "delegation_done":
-                if floor_busy():  # deliver at the next idle moment instead
+                if not mode.allows_delegation:
+                    # Parked until the user exits translation — tell the
+                    # client so its chip stops implying work in progress.
+                    await send_json(ws, {"type": "delegation_parked",
+                                         "id": msg["id"]})
                     ready_delegations.append(msg)
+                    continue
+                if floor_busy():
+                    ready_delegations.append(msg)  # deliver at the next idle moment
                     continue
                 try:
                     await deliver_delegation(msg)
@@ -344,7 +433,7 @@ async def websocket_endpoint(ws: WebSocket):
                 continue
 
             if msg.get("type") == "frame":
-                if msg.get("image"):
+                if msg.get("image") and mode.wants_camera:
                     frame_image = msg["image"]
                     speech_chunks = []
                     await prime(held_audio)
@@ -363,7 +452,7 @@ async def websocket_endpoint(ws: WebSocket):
             speech_chunks = []
             if valid_audio(msg.get("audio")):
                 audio_b64s.append(msg["audio"])
-            image = msg.get("image") or frame_image
+            image = (msg.get("image") or frame_image) if mode.wants_camera else None
             has_audio = bool(audio_b64s)
             is_flush = msg.get("type") == "flush"
 
@@ -382,8 +471,10 @@ async def websocket_endpoint(ws: WebSocket):
                 # involved at all. Incomplete → hold the segments (they stay
                 # in the next turn's content AND warm in the cache) and wait.
                 # A flush turn skips the check: the client waited out the
-                # hold and now wants an answer to whatever we have.
-                if has_audio and not is_flush:
+                # hold and now wants an answer to whatever we have. Translate
+                # mode skips it entirely — an interpreter renders on a short
+                # silence, it does not wait out thinking pauses.
+                if has_audio and not is_flush and mode.uses_smart_turn:
                     pcm = np.concatenate([wav_to_float32(b) for b in audio_b64s])
                     t0 = time.time()
                     complete, prob = await asyncio.get_event_loop().run_in_executor(
@@ -412,16 +503,23 @@ async def websocket_endpoint(ws: WebSocket):
                 frame_image = None
                 held_audio = []
 
-                instruction = turn_instruction(msg, bool(image), has_audio)
+                if mode.name == "translate" and has_audio:
+                    instruction = TRANSLATE_PROMPT
+                else:
+                    instruction = turn_instruction(msg, bool(image), has_audio)
+                    if has_audio:
+                        instruction += MODE_SUFFIX
                 user_msg = {"role": "user", "content": content + [text_part(instruction)]}
                 raw_text, tags = await run_turn(ws, history + [user_msg], interrupted, active,
                                                 tts_backend, expect_transcript=has_audio,
                                                 p_complete=p_complete,
-                                                control_tags=control_tags,
+                                                control_tags=CONTROL_TAGS,
+                                                tts_voice=mode.tts_voice,
                                                 fallback=FLUSH_FALLBACK if is_flush
                                                 else AUDIO_FALLBACK if has_audio else None)
                 remember(user_msg, raw_text)
                 await spawn_delegations(tags)
+                await apply_mode_tags(tags)
             except DISCONNECT_ERRORS:
                 raise
             except Exception:

--- a/src/server.py
+++ b/src/server.py
@@ -109,9 +109,10 @@ TRANSLATE_PROMPT = (
 DELIVER_PROMPT = (
     "System note (not user audio): your background research assistant "
     'just finished the task "{task}". Its answer:\n{answer}\n\n'
-    "Tell the user this answer now: tie it back to what they asked "
-    "earlier, keep every fact exactly as given, 2-5 short sentences, "
-    "plain spoken text."
+    "Tell the user now: one short lead-in sentence tying it back to what "
+    "they asked, then the answer itself word-for-word. Never drop or "
+    "change a name, number, or place — the words above are already "
+    "spoken-style. Plain spoken text."
 )
 DELIVER_FAILED_PROMPT = (
     "System note (not user audio): your background research assistant "

--- a/src/server.py
+++ b/src/server.py
@@ -10,11 +10,13 @@ tail of the utterance.
 """
 
 import asyncio
+import itertools
 import json
 import os
 import sys
 import time
 import traceback
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -38,6 +40,7 @@ from dotenv import load_dotenv
 load_dotenv()  # before importing llama — it reads its config at import time
 
 import llama
+import reasoner
 import tts
 from pipeline import (estimate_tokens, pad_tail_silence, prime_cache,
                       release_client, run_turn, send_json, text_part,
@@ -54,6 +57,42 @@ SYSTEM_PROMPT = (
     "If an audio message is just your own previous reply playing back "
     "(echo), don't answer it — briefly ask what they'd like to talk about."
 )
+
+# Appended to the system prompt only when a reasoner endpoint is
+# configured (.env REASONER_*). An XML element, not a ###-style line:
+# benchmarks/tagbench.py measured much higher tag recall for it on E4B.
+DELEGATE_INSTRUCTION = (
+    " You also have a background research assistant with web access. When "
+    "the user asks you to search, look up, find, or research something, or "
+    "asks about anything current or changing (weather, news, prices, "
+    "scores, openings, \"right now\", \"today\"), you MUST hand the task "
+    "over instead of answering from memory — your knowledge is stale and a "
+    "guess is worse than handing over. To hand over: say one short "
+    "sentence telling the user you're on it, then append <delegate>the "
+    "task, restated to stand alone</delegate> — never speak or mention "
+    "that tag; the result arrives later and you can share it then. "
+    "Everything else, answer yourself and don't use the tag."
+)
+
+# A finished background task is delivered by the voice model, not read out
+# raw: it ties the answer back to the conversation and keeps one voice.
+DELIVER_PROMPT = (
+    'Your background research assistant just finished the task "{task}". '
+    "Its answer:\n{answer}\n\n"
+    "Deliver this answer to the user now: tie it back to what they asked "
+    "earlier, keep every fact exactly as given, 2-5 short sentences, "
+    "plain spoken text."
+)
+DELIVER_FAILED_PROMPT = (
+    'Your background research assistant could not finish the task '
+    '"{task}". Briefly tell the user you couldn\'t get that answer, and '
+    "that they're welcome to ask again. Don't start new research now."
+)
+DELIVER_FALLBACK = "Sorry — I couldn't get an answer for that one."
+
+# One session can only usefully consume a few pending research tasks, and
+# an off-the-rails reply must not queue an HTTP call per imagined tag.
+MAX_PENDING_DELEGATIONS = 3
 
 # The transcript line LEADS the reply: transcribing after the response
 # turns the transcript into a paraphrase from memory (WER 0.39 vs 0.00 on a
@@ -95,6 +134,11 @@ CONTEXT_HEADROOM = 2000
 tts_backend = None
 detector = None  # smart-turn end-of-turn classifier
 
+# Reasoner calls block for up to REASONER_TIMEOUT — keep them off the
+# default executor, which serves the latency-critical path (llama
+# streaming, TTS, the turn classifier, cache priming).
+REASONER_POOL = ThreadPoolExecutor(max_workers=4, thread_name_prefix="reasoner")
+
 
 def load_models():
     global tts_backend, detector
@@ -135,7 +179,10 @@ def turn_instruction(msg: dict, has_image: bool, has_audio: bool) -> str:
 async def websocket_endpoint(ws: WebSocket):
     await ws.accept()
 
-    history: list = [{"role": "system", "content": SYSTEM_PROMPT}]
+    delegation = reasoner.enabled()
+    system = SYSTEM_PROMPT + (DELEGATE_INSTRUCTION if delegation else "")
+    control_tags = ("delegate",) if delegation else ()
+    history: list = [{"role": "system", "content": system}]
 
     interrupted = asyncio.Event()
     active = {"stream": None}
@@ -166,6 +213,91 @@ async def websocket_endpoint(ws: WebSocket):
     speech_chunks: list[str] = []    # streamed-in speech, already cache-primed
     held_audio: list[str] = []       # incomplete-turn segments awaiting continuation
 
+    def remember(user_msg: dict, raw_text: str) -> None:
+        """Store a finished turn verbatim (same bytes → full prefix-cache hit
+        on the next request). A turn the model produced nothing for is never
+        stored — a degenerate message poisons all later requests."""
+        if raw_text.strip():
+            history.append(user_msg)
+            history.append({"role": "assistant", "content": raw_text})
+
+    delegation_ids = itertools.count(1)
+    delegation_tasks: set[asyncio.Task] = set()
+    ready_delegations: list[dict] = []  # finished while the floor was busy
+
+    def floor_busy() -> bool:
+        """The user holds the floor: audio held for a continuation, a
+        mid-utterance chunk stream, or a just-fired barge-in. A delegation
+        result may only be delivered when this is false."""
+        return bool(held_audio or speech_chunks or interrupted.is_set())
+
+    def drain_ready() -> None:
+        """Requeue one finished delegation whenever the floor frees up —
+        called at every point that releases it, because msg_queue only
+        wakes for client traffic and a result must not wait for one."""
+        if ready_delegations and not floor_busy():
+            msg_queue.put_nowait(ready_delegations.pop(0))
+
+    async def run_delegation(task_id: int, task: str) -> None:
+        """Background reasoner call; its outcome re-enters the main loop
+        through msg_queue so delivery is serialized with real turns."""
+        try:
+            answer = await asyncio.get_event_loop().run_in_executor(
+                REASONER_POOL, reasoner.ask, task)
+            # Clamp a verbose answer: it is interpolated into the delivery
+            # prompt and stored in history under a small LLAMA_CTX.
+            if len(answer) > 1500:
+                answer = answer[:1500].rsplit(". ", 1)[0] + "."
+            outcome = {"ok": True, "answer": answer}
+        except Exception as e:
+            print(f"Delegation #{task_id} failed: {e}")
+            outcome = {"ok": False, "answer": ""}
+        await msg_queue.put({"type": "delegation_done", "id": task_id,
+                             "task": task, **outcome})
+
+    async def spawn_delegations(tags: list[tuple[str, str]]) -> None:
+        for name, value in tags:
+            if name == "DELEGATE" and value.strip():
+                if len(delegation_tasks) >= MAX_PENDING_DELEGATIONS:
+                    print(f"Delegation skipped (cap {MAX_PENDING_DELEGATIONS}): {value!r}")
+                    continue
+                task_id = next(delegation_ids)
+                print(f"Delegation #{task_id}: {value!r}")
+                await send_json(ws, {"type": "delegation_started",
+                                     "id": task_id, "task": value})
+                t = asyncio.create_task(run_delegation(task_id, value))
+                delegation_tasks.add(t)
+                t.add_done_callback(delegation_tasks.discard)
+
+    async def deliver_delegation(done: dict) -> None:
+        """A server-initiated turn: the result goes into history and the
+        voice model speaks it. Failures are delivered too — a delegation
+        must never end in silence, which is also why the fallback is the
+        reasoner's own answer: if the model's relay yields nothing
+        speakable (##-markup relapse, transcript-only reply), TTS speaks
+        the answer directly."""
+        interrupted.clear()
+        await send_json(ws, {"type": "delegation_resolved",
+                             "id": done["id"], "ok": done["ok"]})
+        prompt = (DELIVER_PROMPT if done["ok"] else DELIVER_FAILED_PROMPT).format(
+            task=done["task"], answer=done["answer"])
+        user_msg = {"role": "user", "content": [text_part(prompt)]}
+        # expect_transcript=True although there is no audio: history trains
+        # the model to open every reply with ###TRANSCRIPT:, and it often
+        # does so here too (echoing the instruction). The transcript parser
+        # consumes that line and streams the real delivery; with False the
+        # ##-markup cut would swallow the entire reply (observed live).
+        raw_text, tags = await run_turn(ws, history + [user_msg], interrupted,
+                                        active, tts_backend,
+                                        expect_transcript=True,
+                                        control_tags=control_tags,
+                                        proactive=True,
+                                        fallback=done["answer"] if done["ok"]
+                                        else DELIVER_FALLBACK)
+        remember(user_msg, raw_text)
+        await spawn_delegations(tags)  # a delivery may chain deeper research
+        drain_ready()                  # more results may already be waiting
+
     async def prime(audio_b64s: list[str]) -> None:
         """Warm the cache for the turn as it stands so far — reads the live
         history and held camera frame, so it must stay in this scope."""
@@ -184,6 +316,32 @@ async def websocket_endpoint(ws: WebSocket):
                 keep = 1 + max(2, (len(history) - 1) // 2)
                 print(f"Context near limit — dropping {len(history) - keep} oldest messages")
                 history = [history[0]] + history[-(keep - 1):]
+
+            if msg.get("type") == "ready":
+                # The client returned to idle listening (e.g. after a false
+                # barge-in that never became an utterance). A sticky
+                # interrupted flag must not strand queued deliveries — and
+                # the client cleared its own frame-discard flag before
+                # sending this, so delivering now is safe.
+                interrupted.clear()
+                drain_ready()
+                continue
+
+            if msg.get("type") == "delegation_done":
+                if floor_busy():  # deliver at the next idle moment instead
+                    ready_delegations.append(msg)
+                    continue
+                try:
+                    await deliver_delegation(msg)
+                except DISCONNECT_ERRORS:
+                    raise
+                except Exception:
+                    traceback.print_exc()  # keep the session alive
+                    if not msg.get("redelivered"):
+                        msg["redelivered"] = True  # one more try at idle
+                        ready_delegations.append(msg)
+                    await release_client(ws)
+                continue
 
             if msg.get("type") == "frame":
                 if msg.get("image"):
@@ -212,6 +370,7 @@ async def websocket_endpoint(ws: WebSocket):
             if not has_audio and not image and not msg.get("text"):
                 # Mic glitch (or a flush with nothing held) produced no usable media.
                 await release_client(ws)
+                drain_ready()  # the floor is provably free here
                 continue
 
             # From here on any failure (malformed WAV included — valid_audio
@@ -255,26 +414,28 @@ async def websocket_endpoint(ws: WebSocket):
 
                 instruction = turn_instruction(msg, bool(image), has_audio)
                 user_msg = {"role": "user", "content": content + [text_part(instruction)]}
-                raw_text = await run_turn(ws, history + [user_msg], interrupted, active,
-                                          tts_backend, expect_transcript=has_audio,
-                                          p_complete=p_complete,
-                                          fallback=FLUSH_FALLBACK if is_flush
-                                          else AUDIO_FALLBACK if has_audio else None)
-                # Store the turn verbatim (same bytes → full prefix-cache hit
-                # on the next request). Never store a turn the model produced
-                # nothing for — a degenerate message poisons all later requests.
-                if raw_text.strip():
-                    history.append(user_msg)
-                    history.append({"role": "assistant", "content": raw_text})
+                raw_text, tags = await run_turn(ws, history + [user_msg], interrupted, active,
+                                                tts_backend, expect_transcript=has_audio,
+                                                p_complete=p_complete,
+                                                control_tags=control_tags,
+                                                fallback=FLUSH_FALLBACK if is_flush
+                                                else AUDIO_FALLBACK if has_audio else None)
+                remember(user_msg, raw_text)
+                await spawn_delegations(tags)
             except DISCONNECT_ERRORS:
                 raise
             except Exception:
                 traceback.print_exc()  # keep the session alive
                 await release_client(ws)
+
+            # A result that finished while the floor was busy delivers now.
+            drain_ready()
     except DISCONNECT_ERRORS:
         print("Client disconnected")
     finally:
         recv_task.cancel()
+        for t in delegation_tasks:
+            t.cancel()
 
 
 if __name__ == "__main__":

--- a/src/server.py
+++ b/src/server.py
@@ -13,6 +13,7 @@ import asyncio
 import itertools
 import json
 import os
+import re
 import sys
 import time
 import traceback
@@ -68,7 +69,8 @@ DELEGATE_INSTRUCTION = (
     "asks about anything current or changing (weather, news, prices, "
     "scores, openings, \"right now\", \"today\"), you MUST hand the task "
     "over instead of answering from memory — your knowledge is stale and a "
-    "guess is worse than handing over. To hand over: say one short "
+    "guess is worse than handing over. Sports, elections, and rankings "
+    "count as current. To hand over: say one short "
     "sentence telling the user you're on it, then append <delegate>the "
     "task, restated to stand alone</delegate> — never speak or mention "
     "that tag; the result arrives later and you can share it then. "
@@ -134,6 +136,20 @@ MAX_PENDING_DELEGATIONS = 3
 # doesn't know is spoken aloud, task text included. Modes gate ACTING on a
 # tag (spawn_delegations, apply_mode_tags), never parsing it.
 CONTROL_TAGS = ("delegate", "mode")
+
+
+def strip_unfired_tags(text: str, tags: list) -> str:
+    """Remove tags from a turn's stored text when they did NOT fire (task
+    fragment skipped, cap hit, unknown mode, mode tag on a delivery). A
+    tag left in history without its action teaches the model a state the
+    server isn't in — observed live as the model 'translating' from
+    context while the server never switched and the mode chip never
+    appeared."""
+    for name, value in tags:
+        text = re.sub(
+            rf"<\s*{name.lower()}\s*>\s*{re.escape(value)}\s*(<\s*/\s*{name.lower()}\s*>)?",
+            "", text, flags=re.IGNORECASE)
+    return text
 
 # The transcript line LEADS the reply: transcribing after the response
 # turns the transcript into a paraphrase from memory (WER 0.39 vs 0.00 on a
@@ -266,6 +282,7 @@ async def websocket_endpoint(ws: WebSocket):
     delegation_tasks: set[asyncio.Task] = set()
     ready_delegations: list[dict] = []  # finished while the floor was busy
     playing_since = {"t": 0.0}  # last spoken reply is (probably) still playing
+    prompt_tokens = {"last": 0}  # real context size, from llama-server usage
 
     def floor_busy() -> bool:
         """The floor is held by the user (audio held for a continuation, a
@@ -286,18 +303,19 @@ async def websocket_endpoint(ws: WebSocket):
         if mode.allows_delegation and ready_delegations and not floor_busy():
             msg_queue.put_nowait(ready_delegations.pop(0))
 
-    async def switch_mode(name: str) -> None:
+    async def switch_mode(name: str) -> bool:
         """Enter a mode by name (model tag or UI escape hatch). Unknown and
-        already-current names are no-ops, so callers can pass raw values."""
+        already-current names are no-ops, so callers can pass raw values.
+        Returns whether a switch happened."""
         nonlocal mode, frame_image, speech_chunks, held_audio
         name = name.strip().lower()
         if name == mode.name:
-            return
+            return True  # already there — the tag "fired" in every sense
         if name not in MODES:
             # The model confirmed something out loud and then emitted junk —
             # make that diagnosable instead of a silent nothing.
             print(f"Ignoring unknown mode {name!r}")
-            return
+            return False
         mode = MODES[name]
         # Start the new mode clean: a switch through the UI escape hatch can
         # fire with audio held under the OLD mode's gating, and translate
@@ -309,11 +327,15 @@ async def websocket_endpoint(ws: WebSocket):
         print(f"Mode → {mode.name}")
         await send_json(ws, {"type": "mode_changed", "mode": mode.name})
         drain_ready()  # leaving translation frees deferred deliveries
+        return True
 
-    async def apply_mode_tags(tags: list[tuple[str, str]]) -> None:
+    async def apply_mode_tags(tags: list[tuple[str, str]]) -> list:
+        """Returns the mode tags that did NOT fire (for history stripping)."""
+        unfired = []
         for name, value in tags:
-            if name == "MODE":
-                await switch_mode(value)
+            if name == "MODE" and not await switch_mode(value):
+                unfired.append((name, value))
+        return unfired
 
     async def run_delegation(task_id: int, task: str) -> None:
         """Background reasoner call; its outcome re-enters the main loop
@@ -332,24 +354,38 @@ async def websocket_endpoint(ws: WebSocket):
         await msg_queue.put({"type": "delegation_done", "id": task_id,
                              "task": task, **outcome})
 
-    async def spawn_delegations(tags: list[tuple[str, str]]) -> None:
+    async def spawn_delegations(tags: list[tuple[str, str]]) -> list:
+        """Returns the delegate tags that did NOT fire (for history
+        stripping — the model must not believe research is underway)."""
+        delegate_tags = [(n, v) for n, v in tags if n == "DELEGATE"]
         if not delegation or not mode.allows_delegation:
             # The filter still parses <delegate> here (so it is never
             # spoken); without a reasoner, or mid-translation, it must
             # also never fire.
-            return
-        for name, value in tags:
-            if name == "DELEGATE" and value.strip():
-                if len(delegation_tasks) >= MAX_PENDING_DELEGATIONS:
-                    print(f"Delegation skipped (cap {MAX_PENDING_DELEGATIONS}): {value!r}")
-                    continue
-                task_id = next(delegation_ids)
-                print(f"Delegation #{task_id}: {value!r}")
-                await send_json(ws, {"type": "delegation_started",
-                                     "id": task_id, "task": value})
-                t = asyncio.create_task(run_delegation(task_id, value))
-                delegation_tasks.add(t)
-                t.add_done_callback(delegation_tasks.discard)
+            return delegate_tags
+        unfired = []
+        for name, value in delegate_tags:
+            task = value.strip()
+            if len(task.split()) < 3:
+                # An EOS-truncated fragment ('<delegate>search' cut mid-
+                # element) — a one-word task sends the reasoner nothing to
+                # work with (observed live: task 'search' came back as a
+                # clarification request, delivered verbatim).
+                print(f"Delegation skipped (fragment): {task!r}")
+                unfired.append((name, value))
+                continue
+            if len(delegation_tasks) >= MAX_PENDING_DELEGATIONS:
+                print(f"Delegation skipped (cap {MAX_PENDING_DELEGATIONS}): {task!r}")
+                unfired.append((name, value))
+                continue
+            task_id = next(delegation_ids)
+            print(f"Delegation #{task_id}: {task!r}")
+            await send_json(ws, {"type": "delegation_started",
+                                 "id": task_id, "task": task})
+            t = asyncio.create_task(run_delegation(task_id, task))
+            delegation_tasks.add(t)
+            t.add_done_callback(delegation_tasks.discard)
+        return unfired
 
     async def deliver_delegation(done: dict) -> None:
         """A server-initiated turn: the result goes into history and the
@@ -369,18 +405,21 @@ async def websocket_endpoint(ws: WebSocket):
         # does so here too (echoing the instruction). The transcript parser
         # consumes that line and streams the real delivery; with False the
         # ##-markup cut would swallow the entire reply (observed live).
-        raw_text, tags = await run_turn(ws, history + [user_msg], interrupted,
-                                        active, tts_backend,
-                                        expect_transcript=True,
-                                        control_tags=CONTROL_TAGS,
-                                        tts_voice=mode.tts_voice,
-                                        proactive=True,
-                                        fallback=done["answer"] if done["ok"]
-                                        else DELIVER_FALLBACK)
+        raw_text, tags, pt = await run_turn(ws, history + [user_msg], interrupted,
+                                            active, tts_backend,
+                                            expect_transcript=True,
+                                            control_tags=CONTROL_TAGS,
+                                            tts_voice=mode.tts_voice,
+                                            proactive=True,
+                                            fallback=done["answer"] if done["ok"]
+                                            else DELIVER_FALLBACK)
+        if pt:
+            prompt_tokens["last"] = pt
         if raw_text.strip():
             playing_since["t"] = time.time()  # this delivery is now playing
-        remember(user_msg, raw_text)
-        await spawn_delegations(tags)  # a delivery may chain deeper research
+        unfired = await spawn_delegations(tags)  # a delivery may chain research
+        unfired += [(n, v) for n, v in tags if n == "MODE"]  # never applied here
+        remember(user_msg, strip_unfired_tags(raw_text, unfired))
         drain_ready()                  # more results may already be waiting
 
     async def prime(audio_b64s: list[str]) -> None:
@@ -396,11 +435,20 @@ async def websocket_endpoint(ws: WebSocket):
                 break
 
             # Rotate history before the llama context fills: keep the system
-            # prompt and the most recent exchanges.
-            if estimate_tokens(history) > llama.CTX - CONTEXT_HEADROOM:
-                keep = 1 + max(2, (len(history) - 1) // 2)
-                print(f"Context near limit — dropping {len(history) - keep} oldest messages")
+            # prompt and the most recent exchanges. The REAL count from the
+            # last request wins over the estimate — when the estimate
+            # undershoots (camera turns), llama-server silently truncates
+            # the oldest turns first, which reads as the model "forgetting".
+            # Double headroom because the incoming turn isn't counted yet;
+            # drop a quarter (not half) so a rotation is barely noticeable.
+            est = estimate_tokens(history)
+            used = max(est, prompt_tokens["last"])
+            if used > llama.CTX - 2 * CONTEXT_HEADROOM:
+                keep = 1 + max(2, 3 * (len(history) - 1) // 4)
+                print(f"Context near limit (est {est}, real {prompt_tokens['last']}) "
+                      f"— dropping {len(history) - keep} oldest messages")
                 history = [history[0]] + history[-(keep - 1):]
+                prompt_tokens["last"] = 0  # stale after a rotation
 
             if msg.get("type") == "ready":
                 # The client returned to idle listening: playback finished,
@@ -521,18 +569,20 @@ async def websocket_endpoint(ws: WebSocket):
                     if has_audio:
                         instruction += MODE_SUFFIX
                 user_msg = {"role": "user", "content": content + [text_part(instruction)]}
-                raw_text, tags = await run_turn(ws, history + [user_msg], interrupted, active,
-                                                tts_backend, expect_transcript=has_audio,
-                                                p_complete=p_complete,
-                                                control_tags=CONTROL_TAGS,
-                                                tts_voice=mode.tts_voice,
-                                                fallback=FLUSH_FALLBACK if is_flush
-                                                else AUDIO_FALLBACK if has_audio else None)
+                raw_text, tags, pt = await run_turn(ws, history + [user_msg], interrupted, active,
+                                                    tts_backend, expect_transcript=has_audio,
+                                                    p_complete=p_complete,
+                                                    control_tags=CONTROL_TAGS,
+                                                    tts_voice=mode.tts_voice,
+                                                    fallback=FLUSH_FALLBACK if is_flush
+                                                    else AUDIO_FALLBACK if has_audio else None)
+                if pt:
+                    prompt_tokens["last"] = pt
                 if raw_text.strip():
                     playing_since["t"] = time.time()  # reply now playing client-side
-                remember(user_msg, raw_text)
-                await spawn_delegations(tags)
-                await apply_mode_tags(tags)
+                unfired = await spawn_delegations(tags)
+                unfired += await apply_mode_tags(tags)
+                remember(user_msg, strip_unfired_tags(raw_text, unfired))
             except DISCONNECT_ERRORS:
                 raise
             except Exception:

--- a/src/server.py
+++ b/src/server.py
@@ -96,9 +96,11 @@ TRANSLATE_PROMPT = (
     "their original language. Then, on a new line, write ONLY the English "
     "translation of those words — no commentary, no answers, no opinions. "
     "If they already spoke English, restate their words in clear English. "
-    "Exception: if they are clearly addressing YOU with a command to stop "
-    "or change translation (\"stop translating\", \"back to normal\"), "
-    "confirm in one short sentence and append <mode>conversation</mode>."
+    "ONE exception: if their words are a command TO YOU to stop or leave "
+    "translation — like \"stop translating\", \"go back to normal "
+    "conversation\", \"berhenti menerjemahkan\", \"deja de traducir\" — do "
+    "NOT translate it: confirm in one short sentence and end with "
+    "<mode>conversation</mode>."
 )
 
 # A finished background task is delivered by the voice model, not read out
@@ -263,12 +265,17 @@ async def websocket_endpoint(ws: WebSocket):
     delegation_ids = itertools.count(1)
     delegation_tasks: set[asyncio.Task] = set()
     ready_delegations: list[dict] = []  # finished while the floor was busy
+    playing_since = {"t": 0.0}  # last spoken reply is (probably) still playing
 
     def floor_busy() -> bool:
-        """The user holds the floor: audio held for a continuation, a
-        mid-utterance chunk stream, or a just-fired barge-in. A delegation
-        result may only be delivered when this is false."""
-        return bool(held_audio or speech_chunks or interrupted.is_set())
+        """The floor is held by the user (audio held for a continuation, a
+        mid-utterance chunk stream, a just-fired barge-in) or by our own
+        voice: a spoken reply counts as playing until the client's 'ready'
+        says playback ended — a delivery starting mid-playback would cut
+        the reply off mid-sentence. The 30s staleness escape means a lost
+        'ready' can only delay a result, never strand it."""
+        playing = playing_since["t"] and time.time() - playing_since["t"] < 30
+        return bool(held_audio or speech_chunks or interrupted.is_set() or playing)
 
     def drain_ready() -> None:
         """Requeue one finished delegation whenever the floor frees up —
@@ -370,6 +377,8 @@ async def websocket_endpoint(ws: WebSocket):
                                         proactive=True,
                                         fallback=done["answer"] if done["ok"]
                                         else DELIVER_FALLBACK)
+        if raw_text.strip():
+            playing_since["t"] = time.time()  # this delivery is now playing
         remember(user_msg, raw_text)
         await spawn_delegations(tags)  # a delivery may chain deeper research
         drain_ready()                  # more results may already be waiting
@@ -394,11 +403,12 @@ async def websocket_endpoint(ws: WebSocket):
                 history = [history[0]] + history[-(keep - 1):]
 
             if msg.get("type") == "ready":
-                # The client returned to idle listening (e.g. after a false
-                # barge-in that never became an utterance). A sticky
+                # The client returned to idle listening: playback finished,
+                # or a false barge-in never became an utterance. A sticky
                 # interrupted flag must not strand queued deliveries — and
                 # the client cleared its own frame-discard flag before
                 # sending this, so delivering now is safe.
+                playing_since["t"] = 0.0
                 interrupted.clear()
                 drain_ready()
                 continue
@@ -518,6 +528,8 @@ async def websocket_endpoint(ws: WebSocket):
                                                 tts_voice=mode.tts_voice,
                                                 fallback=FLUSH_FALLBACK if is_flush
                                                 else AUDIO_FALLBACK if has_audio else None)
+                if raw_text.strip():
+                    playing_since["t"] = time.time()  # reply now playing client-side
                 remember(user_msg, raw_text)
                 await spawn_delegations(tags)
                 await apply_mode_tags(tags)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -191,6 +191,7 @@ function connect() {
     removePendingUserBubble();
     delegationChips.forEach(chip => chip.remove());  // tasks died with the server
     delegationChips.clear();
+    setSessionMode('conversation');  // a reconnect starts a fresh session
     clearFlushTimer();
     setStatus('disconnected', 'Disconnected');
     setTimeout(connect, 2000);
@@ -249,8 +250,19 @@ function connect() {
       }
       const meta = messagesDiv.querySelector('.msg.assistant:last-child .meta');
       if (meta) meta.textContent += ` · tts ${msg.tts_time}s`;
+    } else if (msg.type === 'mode_changed') {
+      setSessionMode(msg.mode);
     } else if (msg.type === 'delegation_started') {
       addDelegationChip(msg.id, msg.task);
+    } else if (msg.type === 'delegation_parked') {
+      // Finished, but delivery waits out translation mode — the chip must
+      // stop implying work in progress.
+      const chip = delegationChips.get(msg.id);
+      if (chip) {
+        chip.classList.add('parked');
+        chip.querySelector('.task').textContent =
+          'ready — ' + chip.querySelector('.task').textContent;
+      }
     } else if (msg.type === 'delegation_resolved') {
       // The delivery turn follows immediately as a normal spoken turn —
       // give it a fresh assistant bubble, and show it as thinking (which
@@ -288,6 +300,12 @@ function setAssistantMeta(text) {
     currentAssistantEl.appendChild(meta);
   }
   meta.textContent = text;
+}
+
+// ── Session mode (server-driven; the chip's stop button is the escape
+// hatch for when the spoken exit command gets mistranslated) ──
+function setSessionMode(mode) {
+  $('modeChip').hidden = mode !== 'translate';
 }
 
 // ── Delegation chips: a background research task in flight, shown until
@@ -675,6 +693,10 @@ function addMessage(role, text, meta) {
   messagesDiv.scrollTop = messagesDiv.scrollHeight;
   return div;
 }
+
+$('modeStop').addEventListener('click', () => {
+  wsSend({ type: 'set_mode', mode: 'conversation' });
+});
 
 cameraToggle.addEventListener('click', () => {
   cameraEnabled = !cameraEnabled;

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -157,7 +157,18 @@ function setState(newState) {
   }
 }
 
-function goListening() { setState('listening'); setStatus('connected', 'Connected'); }
+// announce=false when the mic may be live (barge-in): 'ready' tells the
+// server the floor is free, so it must only be sent from genuine idle.
+// Clearing ignoreIncomingAudio in the same breath keeps the two ends
+// aligned: a server that may now deliver ⇔ a client that will play it.
+function goListening(announce = true) {
+  setState('listening');
+  setStatus('connected', 'Connected');
+  if (announce && !speechActive) {
+    ignoreIncomingAudio = false;
+    wsSend({ type: 'ready' });
+  }
+}
 function goProcessing() { setState('processing'); setStatus('processing', 'Processing'); }
 
 // ── WebSocket ──
@@ -178,6 +189,8 @@ function connect() {
     framePrefetched = false;
     serverHoldingAudio = false;
     removePendingUserBubble();
+    delegationChips.forEach(chip => chip.remove());  // tasks died with the server
+    delegationChips.clear();
     clearFlushTimer();
     setStatus('disconnected', 'Disconnected');
     setTimeout(connect, 2000);
@@ -206,7 +219,10 @@ function connect() {
       fillUserBubble(msg.transcription);
     } else if (msg.type === 'turn_final') {
       if (ignoreIncomingAudio) return;
-      if (!msg.spoke && !msg.transcription) {
+      if (msg.proactive) {
+        // Server-initiated delivery: its "transcript" is the model's own
+        // echo, and there is no pending user bubble to fill or remove.
+      } else if (!msg.spoke && !msg.transcription) {
         removePendingUserBubble();  // glitch/empty turn — nothing was heard
       } else {
         fillUserBubble(msg.transcription);
@@ -215,6 +231,7 @@ function connect() {
       if (t.llm_time) {
         setAssistantMeta((t.ttfa_s ? `first audio ${t.ttfa_s}s · ` : '') + `model ${t.llm_time}s`);
       }
+      currentAssistantEl = null;  // the next turn gets its own bubble
       if (!msg.spoke) goListening();  // no audio will follow
     } else if (msg.type === 'audio_start') {
       if (ignoreIncomingAudio) return;
@@ -232,6 +249,15 @@ function connect() {
       }
       const meta = messagesDiv.querySelector('.msg.assistant:last-child .meta');
       if (meta) meta.textContent += ` · tts ${msg.tts_time}s`;
+    } else if (msg.type === 'delegation_started') {
+      addDelegationChip(msg.id, msg.task);
+    } else if (msg.type === 'delegation_resolved') {
+      // The delivery turn follows immediately as a normal spoken turn —
+      // give it a fresh assistant bubble, and show it as thinking (which
+      // also arms the processing watchdog) if we were sitting idle.
+      currentAssistantEl = null;
+      removeDelegationChip(msg.id);
+      if (state === 'listening') goProcessing();
     }
   };
 }
@@ -262,6 +288,26 @@ function setAssistantMeta(text) {
     currentAssistantEl.appendChild(meta);
   }
   meta.textContent = text;
+}
+
+// ── Delegation chips: a background research task in flight, shown until
+// its answer arrives as a normal spoken turn. ──
+const delegationChips = new Map();
+
+function addDelegationChip(id, task) {
+  const div = document.createElement('div');
+  div.className = 'delegation-chip';
+  div.innerHTML = `${LOADING_DOTS}<span class="task"></span>`;
+  div.querySelector('.task').textContent = task;
+  messagesDiv.appendChild(div);
+  messagesDiv.scrollTop = messagesDiv.scrollHeight;
+  delegationChips.set(id, div);
+}
+
+function removeDelegationChip(id) {
+  const chip = delegationChips.get(id);
+  delegationChips.delete(id);
+  if (chip) chip.remove();
 }
 
 function pendingUserBubble() {
@@ -418,6 +464,9 @@ function handleVadFrame(probs, frame) {
       speechActive = false;
       uttFrames = [];
       uttSamplesSent = 0;
+      // The barge-in was a false alarm: re-announce idle so the server's
+      // interrupted flag doesn't strand a queued delegation delivery.
+      goListening();
       console.log('phantom capture reset (no speech after barge-in)');
       return;
     }
@@ -488,7 +537,7 @@ function triggerBargeIn() {
   stopPlayback();
   ignoreIncomingAudio = true;
   wsSend({ type: 'interrupt' });
-  goListening();
+  goListening(false);  // the mic is live — the floor is NOT free
   prefetchFrame();
   startUtteranceCapture();
   console.log('Barge-in: interrupted playback');
@@ -497,7 +546,12 @@ function triggerBargeIn() {
 function handleSpeechEnd(audio) {
   const wasStreaming = speechActive && uttSamplesSent > 0;
   speechActive = false; // always reset — a leak here streams mic audio forever
-  if (state !== 'listening' || !wsOpen()) return;
+  if (state !== 'listening' || !wsOpen()) {
+    // Utterance dropped (e.g. it ended while the assistant was speaking):
+    // its prefetched frame is stale now — the next utterance sends a fresh one.
+    framePrefetched = false;
+    return;
+  }
 
   clearFlushTimer();
   serverHoldingAudio = false;
@@ -654,6 +708,9 @@ async function init() {
       framePrefetched = false;
       speechActive = false;
       if (serverHoldingAudio) startFlushTimer();
+      // A false barge-in ends here: re-announce idle so a delegation
+      // result deferred by the interrupt isn't stranded.
+      if (state === 'listening') goListening();
       console.log('VAD misfire (too short)');
     },
     onFrameProcessed: (probs, frame) => handleVadFrame(probs, Float32Array.from(frame)),

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -316,6 +316,36 @@
     letter-spacing: 0.02em;
   }
 
+  /* Active session mode (translation) with its escape hatch */
+  .mode-chip {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 8px 5px 14px;
+    border-radius: 100px;
+    background: var(--c-speak-dim);
+    color: var(--c-speak);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+
+  .mode-chip[hidden] { display: none; }
+
+  .mode-stop {
+    font-family: var(--font-body);
+    font-size: 11px;
+    font-weight: 600;
+    padding: 3px 10px;
+    border: 1px solid rgba(129,140,248,0.25);
+    border-radius: 100px;
+    background: transparent;
+    color: var(--c-speak);
+    cursor: pointer;
+  }
+
+  .mode-stop:hover { background: rgba(129,140,248,0.15); }
+
   /* A background research task in flight (delegation) */
   .delegation-chip {
     align-self: flex-start;
@@ -331,6 +361,10 @@
   }
 
   .delegation-chip .loading-dots span { background: var(--c-process); }
+
+  /* Result ready but parked (e.g. waiting out translation mode) */
+  .delegation-chip.parked .loading-dots { display: none; }
+  .delegation-chip.parked { color: var(--c-listen); background: var(--c-listen-dim); }
 
   .loading-dots {
     display: inline-flex;

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -316,6 +316,22 @@
     letter-spacing: 0.02em;
   }
 
+  /* A background research task in flight (delegation) */
+  .delegation-chip {
+    align-self: flex-start;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 7px 14px;
+    border-radius: 100px;
+    background: var(--c-process-dim);
+    color: var(--c-process);
+    font-size: 12px;
+    animation: msg-in 0.25s ease-out;
+  }
+
+  .delegation-chip .loading-dots span { background: var(--c-process); }
+
   .loading-dots {
     display: inline-flex;
     gap: 4px;

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -7,10 +7,13 @@ PARLOR_TEST_URL=ws://host:port/ws to test an already-running server instead
 (log- and process-based tests skip).
 """
 
+import http.server
+import json
 import os
 import socket
 import subprocess
 import sys
+import threading
 import time
 import urllib.request
 from dataclasses import dataclass
@@ -25,7 +28,64 @@ import fixtures  # noqa: E402
 
 TEST_PORT = 8821
 TEST_LLAMA_PORT = 8822
+TEST_REASONER_PORT = 8823
 STARTUP_TIMEOUT_S = 300
+
+# Distinctive so a delivery turn provably carries the reasoner's facts.
+MOCK_ANSWER = ("The clear winner right now is Pizzarium Bonci near the "
+               "Vatican, famous for its crispy square pizza slices.")
+
+
+class _ReasonerHandler(http.server.BaseHTTPRequestHandler):
+    """OpenAI-compatible chat endpoint the suite's server delegates to.
+    Task-text triggers keep the paths deterministic: 'stock' → 500 (the
+    failure path, see delegate_stock), 'naples' → an 8s stall (the
+    conversation-continues-while-pending path, see delegate_naples). It
+    also insists on the real request shape — a dropped auth header or a
+    wrong path must fail loudly, not pass silently."""
+
+    def do_POST(self):
+        if (not self.path.endswith("/chat/completions")
+                or not self.headers.get("Authorization", "").startswith("Bearer ")):
+            self.send_response(401)
+            self.end_headers()
+            return
+        raw = self.rfile.read(int(self.headers["Content-Length"]))
+        self.server.requests.append(json.loads(raw))
+        low = raw.lower()
+        if b"stock" in low:
+            self.send_response(500)
+            self.end_headers()
+            return
+        if b"naples" in low:
+            time.sleep(8)
+        payload = json.dumps(
+            {"choices": [{"message": {"content": MOCK_ANSWER}}]}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture(scope="session")
+def reasoner_mock():
+    if os.environ.get("PARLOR_TEST_URL"):
+        yield None  # the external server has its own reasoner config
+        return
+    with socket.socket() as s:
+        if s.connect_ex(("127.0.0.1", TEST_REASONER_PORT)) == 0:
+            pytest.fail(f"port {TEST_REASONER_PORT} is already in use — kill "
+                        f"the stale mock (lsof -ti :{TEST_REASONER_PORT}) and rerun")
+    srv = http.server.ThreadingHTTPServer(("127.0.0.1", TEST_REASONER_PORT),
+                                          _ReasonerHandler)
+    srv.requests = []
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    yield srv
+    srv.shutdown()
 
 
 @dataclass
@@ -43,7 +103,7 @@ class Server:
 
 
 @pytest.fixture(scope="session")
-def server(tmp_path_factory) -> Server:
+def server(tmp_path_factory, reasoner_mock) -> Server:
     fixtures.generate_all()
 
     external = os.environ.get("PARLOR_TEST_URL")
@@ -64,9 +124,14 @@ def server(tmp_path_factory) -> Server:
     log_path = tmp_path_factory.mktemp("server") / "server.log"
     # MODEL pinned so changing the product default can't silently change
     # what the suite measures ("e2b" also passes and is ~2x faster if you
-    # are iterating on tests).
+    # are iterating on tests). The reasoner points at the suite's mock, so
+    # every e2e test runs under the delegation-enabled system prompt —
+    # exactly what production runs when a key is configured.
     env = {**os.environ, "PORT": str(TEST_PORT), "LLAMA_PORT": str(TEST_LLAMA_PORT),
-           "LLAMA_CTX": "4096", "MODEL": os.environ.get("MODEL", "e4b")}
+           "LLAMA_CTX": "4096", "MODEL": os.environ.get("MODEL", "e4b"),
+           "REASONER_BASE_URL": f"http://127.0.0.1:{TEST_REASONER_PORT}/v1",
+           "REASONER_API_KEY": "test-key", "REASONER_MODEL": "mock-model",
+           "REASONER_TIMEOUT": "20"}
     env.pop("LLAMA_SERVER_URL", None)
     with open(log_path, "w") as log:
         proc = subprocess.Popen([sys.executable, "server.py"], cwd=SRC, env=env,

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -134,8 +134,13 @@ def server(tmp_path_factory, reasoner_mock) -> Server:
     # are iterating on tests). The reasoner points at the suite's mock, so
     # every e2e test runs under the delegation-enabled system prompt —
     # exactly what production runs when a key is configured.
+    # TEMPERATURE pinned to 0: the suite verifies machinery and must be
+    # deterministic — at 0.7 every delegation/mode-switch ask is a ~0.8
+    # coin flip and some run always loses one. Production recall at real
+    # temperature is tagbench --production's job, not the suite's.
     env = {**os.environ, "PORT": str(TEST_PORT), "LLAMA_PORT": str(TEST_LLAMA_PORT),
            "LLAMA_CTX": "4096", "MODEL": os.environ.get("MODEL", "e4b"),
+           "TEMPERATURE": os.environ.get("TEMPERATURE", "0"),
            "REASONER_BASE_URL": f"http://127.0.0.1:{TEST_REASONER_PORT}/v1",
            "REASONER_API_KEY": "test-key", "REASONER_MODEL": "mock-model",
            "REASONER_TIMEOUT": "20"}

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -32,8 +32,13 @@ TEST_REASONER_PORT = 8823
 STARTUP_TIMEOUT_S = 300
 
 # Distinctive so a delivery turn provably carries the reasoner's facts.
+# The stalled weather task gets a weather-shaped answer: the delivery
+# prompt demands word-for-word relay, and a mismatched answer (pizza for
+# a weather question) makes the model reject it and hallucinate instead.
 MOCK_ANSWER = ("The clear winner right now is Pizzarium Bonci near the "
                "Vatican, famous for its crispy square pizza slices.")
+MOCK_WEATHER_ANSWER = ("The weather in Naples right now is sunny and "
+                       "twenty-nine degrees, with clear skies all afternoon.")
 
 
 class _ReasonerHandler(http.server.BaseHTTPRequestHandler):
@@ -57,10 +62,12 @@ class _ReasonerHandler(http.server.BaseHTTPRequestHandler):
             self.send_response(500)
             self.end_headers()
             return
+        answer = MOCK_ANSWER
         if b"naples" in low:
             time.sleep(8)
+            answer = MOCK_WEATHER_ANSWER
         payload = json.dumps(
-            {"choices": [{"message": {"content": MOCK_ANSWER}}]}).encode()
+            {"choices": [{"message": {"content": answer}}]}).encode()
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(payload)))

--- a/src/tests/test_conversation.py
+++ b/src/tests/test_conversation.py
@@ -57,7 +57,12 @@ def test_continuation_merges_held_audio(session):
     assert t.marker == "complete"
     merged = (t.transcription or "").lower()
     assert "ask" in merged and "paris" in merged, f"lost part of the utterance: {merged!r}"
-    assert any(w in t.text.lower() for w in ("weather", "paris", "trip"))
+    # A weather question is delegation bait (DELEGATE_INSTRUCTION): the
+    # reply may answer directly or acknowledge and hand it to the reasoner
+    # — either proves the model worked from the full merged utterance.
+    reply = t.text.lower()
+    on_topic = any(w in reply for w in ("weather", "paris", "trip", "forecast"))
+    assert on_topic or session.wait_for("delegation_started", timeout=5), reply
 
 
 @pytest.mark.skip(reason="the TTS fixture has finished-sounding falling prosody, which "

--- a/src/tests/test_delegation.py
+++ b/src/tests/test_delegation.py
@@ -69,7 +69,8 @@ def test_conversation_continues_while_delegation_runs(server, session, reasoner_
     assert resolved and resolved["ok"] is True
     delivery = session.collect_turn(timeout=60)
     assert delivery.marker == "complete", delivery
-    assert "bonci" in delivery.text.lower() or "pizzarium" in delivery.text.lower()
+    assert "twenty-nine" in delivery.text.lower() or "sunny" in delivery.text.lower(), (
+        f"delivery lost the answer: {delivery.text!r}")
 
 
 def test_failed_delegation_is_spoken_not_silent(server, session):

--- a/src/tests/test_delegation.py
+++ b/src/tests/test_delegation.py
@@ -1,0 +1,89 @@
+"""Delegation e2e: the model hands research tasks to the background
+reasoner, and the answer comes back as a proactive spoken turn. The
+reasoner is the deterministic mock in conftest.py — no network, no API
+key — so these tests exercise the full production path: audio in →
+<delegate> tag → background HTTP call → idle-gated delivery turn.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import util  # noqa: E402
+from conftest import MOCK_ANSWER  # noqa: E402
+
+
+def delegate_turn(session, fixture, tries=2):
+    """Send a delegate-worthy utterance; at temperature 0.7 the model
+    occasionally acks without emitting the tag, so retry once. A
+    systematic recall regression still fails loudly — two consecutive
+    misses on a MUST-delegate ask is real, not noise."""
+    for _ in range(tries):
+        t = session.turn(util.audio(fixture))
+        started = session.wait_for("delegation_started", timeout=10)
+        if started:
+            return t, started
+    raise AssertionError(
+        f"model never delegated {fixture!r} in {tries} tries — last ack {t.text!r}")
+
+
+def test_research_question_is_delegated_and_delivered(server, session, reasoner_mock):
+    server.require_managed()  # the mock env is wired by the suite's server
+    requests_before = len(reasoner_mock.requests)
+    t, started = delegate_turn(session, "delegate_pizza")
+    # The acknowledgment turn speaks, and no tag markup may reach the client.
+    assert t.marker == "complete", t
+    assert "<" not in t.text and "delegate" not in t.text.lower()
+    assert started["task"].strip()
+
+    resolved = session.wait_for("delegation_resolved", timeout=30)
+    assert resolved and resolved["ok"] is True
+
+    delivery = session.collect_turn(timeout=60)
+    assert delivery.marker == "complete", delivery  # spoken, not just text
+    # The reasoner's facts survived Gemma's near-verbatim relay.
+    assert "bonci" in delivery.text.lower() or "pizzarium" in delivery.text.lower(), (
+        f"delivery lost the answer: {delivery.text!r} (mock said: {MOCK_ANSWER!r})")
+    # This turn's task reached the mock (the list outlives other tests).
+    assert len(reasoner_mock.requests) > requests_before
+    assert "pizza" in str(reasoner_mock.requests[-1]).lower()
+
+
+def test_conversation_continues_while_delegation_runs(server, session, reasoner_mock):
+    server.require_managed()
+    delegate_turn(session, "delegate_naples")  # mock stalls this task 8s
+
+    # Ask something else while the background task is still running: the
+    # answer must come back BEFORE the delegation delivery.
+    t2 = session.turn(util.audio("capital_france"))
+    assert t2.marker == "complete" and "paris" in t2.text.lower()
+
+    resolved = session.wait_for("delegation_resolved", timeout=30)
+    assert resolved and resolved["ok"] is True
+    delivery = session.collect_turn(timeout=60)
+    assert delivery.marker == "complete", delivery
+    assert "bonci" in delivery.text.lower() or "pizzarium" in delivery.text.lower()
+
+
+def test_failed_delegation_is_spoken_not_silent(server, session):
+    server.require_managed()
+    delegate_turn(session, "delegate_stock")  # 'stock' → mock 500s
+
+    resolved = session.wait_for("delegation_resolved", timeout=30)
+    assert resolved and resolved["ok"] is False
+
+    apology = session.collect_turn(timeout=60)
+    assert apology.marker == "complete" and apology.text.strip(), apology
+
+    # The session survives a failed delegation.
+    t2 = session.turn(util.audio("capital_france"))
+    assert t2.marker == "complete"
+    assert "paris" in t2.text.lower()
+
+
+def test_plain_question_is_not_delegated(server, session):
+    server.require_managed()
+    t = session.turn(util.audio("capital_france"))
+    assert "paris" in t.text.lower()
+    assert session.wait_for("delegation_started", timeout=3) is None

--- a/src/tests/test_delegation.py
+++ b/src/tests/test_delegation.py
@@ -14,18 +14,24 @@ import util  # noqa: E402
 from conftest import MOCK_ANSWER  # noqa: E402
 
 
-def delegate_turn(session, fixture, tries=2):
+def delegate_turn(session, fixture):
     """Send a delegate-worthy utterance; at temperature 0.7 the model
-    occasionally acks without emitting the tag, so retry once. A
-    systematic recall regression still fails loudly — two consecutive
-    misses on a MUST-delegate ask is real, not noise."""
-    for _ in range(tries):
-        t = session.turn(util.audio(fixture))
+    occasionally acks without emitting the tag. The retry uses an
+    ALTERNATE phrasing ({fixture}_alt): re-sending identical audio tends
+    to reproduce the identical tagless completion (cached prefix), so
+    only different words give an independent sample. Two misses across
+    two phrasings of a MUST-delegate ask is a real regression."""
+    for name in (fixture, f"{fixture}_alt"):
+        t = session.turn(util.audio(name))
+        if t.marker == "incomplete":
+            # smart-turn held it: flush rather than re-speak, which would
+            # merge two copies of the utterance into one turn.
+            t = session.turn({"type": "flush"})
         started = session.wait_for("delegation_started", timeout=10)
         if started:
             return t, started
     raise AssertionError(
-        f"model never delegated {fixture!r} in {tries} tries — last ack {t.text!r}")
+        f"model never delegated {fixture!r} (either phrasing) — last ack {t.text!r}")
 
 
 def test_research_question_is_delegated_and_delivered(server, session, reasoner_mock):

--- a/src/tests/test_history.py
+++ b/src/tests/test_history.py
@@ -1,0 +1,51 @@
+"""rotate_history unit tests — no server, runs in milliseconds.
+
+Rotation is pure list logic but only reachable e2e after ~15 real-model
+turns, so its invariants are pinned here: the system prompt survives
+exactly once, the kept slice starts on a user message (an orphaned
+assistant reply describes words that no longer exist — an in-context
+lesson in transcribing from nothing), and tiny histories pass through
+untouched (slicing a bare [system] would duplicate the system prompt).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from server import rotate_history  # noqa: E402
+
+
+def make_history(pairs: int) -> list:
+    h = [{"role": "system", "content": "sys"}]
+    for i in range(pairs):
+        h.append({"role": "user", "content": f"u{i}"})
+        h.append({"role": "assistant", "content": f"a{i}"})
+    return h
+
+
+@pytest.mark.parametrize("pairs", range(2, 12))
+def test_rotation_never_orphans_a_reply(pairs):
+    h = rotate_history(make_history(pairs))
+    assert h[0]["role"] == "system"
+    assert h[1]["role"] == "user", f"orphaned assistant at {pairs} pairs: {h[1]}"
+    roles = [m["role"] for m in h[1:]]
+    assert roles == ["user", "assistant"] * (len(roles) // 2)
+
+
+def test_rotation_drops_oldest_and_keeps_newest():
+    h = make_history(8)
+    out = rotate_history(h)
+    assert len(out) < len(h)
+    assert out[-1] == h[-1] and out[1]["role"] == "user"
+    assert sum(m["role"] == "system" for m in out) == 1
+
+
+@pytest.mark.parametrize("pairs", [0, 1])
+def test_tiny_history_is_untouched(pairs):
+    # Nothing droppable — and a sliced bare [system] would come back as
+    # [system, system], growing a copy per turn.
+    h = make_history(pairs)
+    assert rotate_history(h) == h

--- a/src/tests/test_robustness.py
+++ b/src/tests/test_robustness.py
@@ -60,7 +60,10 @@ def test_context_rotation_survives(server, session):
     small LLAMA_CTX to make this cheap) — the session must keep working."""
     server.require_managed()
     rotated = False
-    for _ in range(8):
+    # Generous turn budget: how fast history grows depends on the token
+    # estimate and CONTEXT_HEADROOM tuning, and the loop exits early the
+    # moment rotation fires.
+    for _ in range(14):
         t = session.turn({**audio("capital_france"), "image": fx.make_image_b64()}, timeout=120)
         assert t.marker == "complete", f"turn failed before/during rotation: {t}"
         if "dropping" in server.log():

--- a/src/tests/test_stream_parser.py
+++ b/src/tests/test_stream_parser.py
@@ -117,3 +117,123 @@ def test_streaming_matches_batch_for_every_split_point():
     batch = run([CANONICAL])
     for i in range(1, len(CANONICAL)):
         assert run([CANONICAL[:i], CANONICAL[i:]]) == batch, f"diverged at split {i}"
+
+
+# ── control tags ──────────────────────────────────────────────────────────
+# Why XML elements rather than ###NAME: lines: see TagFilter in pipeline.py.
+
+TAGS = ("delegate", "mode")
+
+
+def run_tags(deltas, expect_transcript=True):
+    """-> (spoken sentences, transcript, extracted tags)"""
+    p = StreamParser(expect_transcript, control_tags=TAGS)
+    spoken = []
+    for d in deltas:
+        spoken += p.feed(d)
+    tail, transcript = p.finalize()
+    return spoken + tail, transcript, p.tags
+
+
+DELEGATED = ("###TRANSCRIPT: What's the best pizza in Rome?\n"
+             "Great question — let me dig into that. "
+             "<delegate>best pizza places in Rome right now</delegate>")
+
+
+@pytest.mark.parametrize("deltas", [
+    [DELEGATED],
+    char_deltas(DELEGATED),
+    ["###TRANSCRIPT: What's the best pizza in Rome?", "\n",
+     "Great question — let me dig into that.", " <", "delegate", ">",
+     "best pizza places", " in Rome right now", "</", "delegate", ">"],
+], ids=["batch", "char3", "tokenwise"])
+def test_delegate_tag_extracted_never_spoken(deltas):
+    spoken, transcript, tags = run_tags(deltas)
+    assert transcript == "What's the best pizza in Rome?"
+    assert spoken == ["Great question — let me dig into that."]
+    assert tags == [("DELEGATE", "best pizza places in Rome right now")]
+
+
+def test_open_tag_value_is_never_extracted_or_spoken_early():
+    # The value may still be streaming: extracting at the first feed would
+    # fire a delegation with half the task, and none of it may reach TTS.
+    p = StreamParser(control_tags=TAGS)
+    assert p.feed("###TRANSCRIPT: hi\nOk. <delegate>first half") == ["Ok."]
+    assert p.tags == []
+    p.feed(" second half</delegate>")
+    assert p.tags == [("DELEGATE", "first half second half")]
+
+
+def test_unclosed_tag_at_stream_end_is_dropped_not_spoken():
+    # Truncated stream (or the model forgot the close tag): firing a
+    # half-task or speaking the markup are both worse than dropping it.
+    spoken, _, tags = run_tags(["###TRANSCRIPT: hi\n", "Sure. ",
+                                "<delegate>look something up"])
+    assert spoken == ["Sure."]
+    assert tags == []
+
+
+def test_speech_resumes_after_a_tag():
+    spoken, _, tags = run_tags(["###TRANSCRIPT: hi\n",
+                                "One moment. <mode>translate target=en</mode>",
+                                " Switching now. "])
+    assert spoken == ["One moment.", "Switching now."]
+    assert tags == [("MODE", "translate target=en")]
+
+
+def test_unrecognized_markup_keeps_the_terminal_cut():
+    spoken, _, tags = run_tags(["###TRANSCRIPT: hi\n", "Hello. ",
+                                "## Notes: stuff. Never spoken. "])
+    assert spoken == ["Hello."]
+    assert tags == []
+
+
+def test_literal_angle_bracket_is_released():
+    spoken, _, tags = run_tags(["###TRANSCRIPT: hi\n",
+                                "Five < 10 is true. <delegate>x</delegate>"])
+    assert spoken == ["Five < 10 is true."]
+    assert tags == [("DELEGATE", "x")]
+
+
+def test_unknown_element_is_released_as_text():
+    # Only configured names are control tags; other markup-ish text the
+    # model produces is ordinary (spoken) output.
+    spoken, _, tags = run_tags(["###TRANSCRIPT: hi\n", "I like <b>bold</b> text. "])
+    assert spoken == ["I like <b>bold</b> text."]
+    assert tags == []
+
+
+def test_tag_only_reply_yields_tag_and_no_speech():
+    spoken, _, tags = run_tags(["<delegate>solo task</delegate>"])
+    assert spoken == []
+    assert tags == [("DELEGATE", "solo task")]
+
+
+def test_no_transcript_mode_extracts_tags():
+    spoken, transcript, tags = run_tags(
+        ["I see a cat. ", "<mode>conversation</mode>"], expect_transcript=False)
+    assert transcript is None
+    assert spoken == ["I see a cat."]
+    assert tags == [("MODE", "conversation")]
+
+
+def test_back_to_back_tags():
+    spoken, _, tags = run_tags(["###TRANSCRIPT: hi\n", "On it. ",
+                                "<delegate>task one</delegate>",
+                                "<mode>translate target=en</mode>"])
+    assert spoken == ["On it."]
+    assert tags == [("DELEGATE", "task one"), ("MODE", "translate target=en")]
+
+
+def test_streaming_matches_batch_for_every_split_point_with_tags():
+    batch = run_tags([DELEGATED])
+    for i in range(1, len(DELEGATED)):
+        assert run_tags([DELEGATED[:i], DELEGATED[i:]]) == batch, f"diverged at split {i}"
+
+
+def test_parser_without_control_tags_is_unchanged():
+    # No control_tags configured → a delegate element is just text; the
+    # ##-markup cut still applies to hash markup.
+    spoken, _, _ = run(["###TRANSCRIPT: hi\n", "Hello. ",
+                        "<delegate>x</delegate> ## notes"])
+    assert spoken == ["Hello.", "<delegate>x</delegate>"]

--- a/src/tests/test_stream_parser.py
+++ b/src/tests/test_stream_parser.py
@@ -13,7 +13,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from pipeline import StreamParser  # noqa: E402
+from pipeline import StreamParser, echoes_instruction  # noqa: E402
 
 
 def run(deltas, expect_transcript=True):
@@ -270,6 +270,40 @@ def test_streaming_matches_batch_for_every_split_point_with_tags(text):
     batch = run_tags([text])
     for i in range(1, len(text)):
         assert run_tags([text[:i], text[i:]]) == batch, f"diverged at split {i}"
+
+
+# ── instruction-echo guard ────────────────────────────────────────────────
+# Live bug: on a flush turn the model sometimes echoes the instruction
+# text into its ###TRANSCRIPT: line, and the client displays it as the
+# user's words. The guard suppresses any transcript sharing a 5-word run
+# with the turn's instruction.
+
+def test_instruction_echo_is_detected_against_production_prompts():
+    import server
+    flush = server.FLUSH_PROMPT.format(camera="")
+    # The observed leak: instruction text verbatim (with or without the
+    # model tacking invented words on the end).
+    assert echoes_instruction("The user paused mid-thought, so on a new line:", flush)
+    assert echoes_instruction(
+        "The user paused mid-thought, so on a new line: hello there", flush)
+    respond = server.RESPOND_PROMPT.format(camera="")
+    assert echoes_instruction(
+        "followed by the exact words the user said in their audio message", respond)
+
+
+def test_genuine_transcripts_pass_the_echo_guard():
+    import server
+    for prompt in (server.FLUSH_PROMPT.format(camera=""),
+                   server.RESPOND_PROMPT.format(camera=""),
+                   server.TRANSLATE_PROMPT):
+        for said in ("What is the capital of France?",
+                     "So the thing I wanted to ask you about is the weather "
+                     "in Paris for my trip next week.",
+                     "I have been trying to learn English for a few months now.",
+                     "Please respond to them, all of them, by email."):
+            assert not echoes_instruction(said, prompt), (said, prompt[:40])
+    # Too short to judge stays visible.
+    assert not echoes_instruction("On a new line", "so on a new line: x")
 
 
 def test_production_filter_knows_every_control_tag():

--- a/src/tests/test_stream_parser.py
+++ b/src/tests/test_stream_parser.py
@@ -164,13 +164,28 @@ def test_open_tag_value_is_never_extracted_or_spoken_early():
     assert p.tags == [("DELEGATE", "first half second half")]
 
 
-def test_unclosed_tag_at_stream_end_is_dropped_not_spoken():
-    # Truncated stream (or the model forgot the close tag): firing a
-    # half-task or speaking the markup are both worse than dropping it.
+def test_unclosed_tag_at_stream_end_fires_but_is_never_spoken():
+    # The model often hits EOS before the close tag (measured live: a
+    # third of '<mode>conversation' exits ended unclosed). At end of
+    # stream the value is as complete as it will ever be — extract it,
+    # still never speak it.
     spoken, _, tags = run_tags(["###TRANSCRIPT: hi\n", "Sure. ",
                                 "<delegate>look something up"])
     assert spoken == ["Sure."]
-    assert tags == []
+    assert tags == [("DELEGATE", "look something up")]
+    spoken, _, tags = run_tags(["###TRANSCRIPT: ok\n",
+                                "Back to normal. <mode>conversation"])
+    assert spoken == ["Back to normal."]
+    assert tags == [("MODE", "conversation")]
+
+
+def test_half_open_tag_at_stream_end_still_drops():
+    # Only a complete opening bracket with a value fires at EOS; a
+    # fragment ('<dele', '<mode>') never does.
+    for tail in ["<dele", "<mode>", "<mode >  "]:
+        spoken, _, tags = run_tags(["###TRANSCRIPT: hi\n", "Okay. ", tail])
+        assert spoken == ["Okay."], tail
+        assert tags == [], tail
 
 
 def test_speech_resumes_after_a_tag():

--- a/src/tests/test_stream_parser.py
+++ b/src/tests/test_stream_parser.py
@@ -336,3 +336,36 @@ def test_parser_without_control_tags_is_unchanged():
     spoken, _, _ = run(["###TRANSCRIPT: hi\n", "Hello. ",
                         "<delegate>x</delegate> ## notes"])
     assert spoken == ["Hello.", "<delegate>x</delegate>"]
+
+
+def test_no_speech_annotations_are_not_user_words():
+    # A transcript that is entirely a bracketed annotation reports that
+    # there were no words — shown/stored as user speech it becomes a
+    # hallucination ('[Silence]' appeared as a user bubble, live).
+    from pipeline import NO_SPEECH_RE
+    for t in ["(no speech)", "(No Speech)", "no speech", "No speech.",
+              "(noise)", "[Silence]", "*sigh*", "(background noise)",
+              "(static hum)", "[inaudible]"]:
+        assert NO_SPEECH_RE.match(t), t
+    # Real utterances — including ones that merely start with or contain
+    # such words — must pass through untouched.
+    for t in ["Silence is golden, don't you think?",
+              "What is the capital of France?",
+              "I heard a noise in the garden (I think).",
+              "(", "(a very long parenthesized ramble that goes on and on "
+              "far past any plausible annotation length, word after word)"]:
+        assert not NO_SPEECH_RE.match(t), t
+
+
+def test_quoted_prompt_phrases_are_not_echoes():
+    # The translate prompt QUOTES the exit phrases users actually say — a
+    # genuine "go back to normal conversation" must not read as an
+    # instruction echo (pre-fix it did, and the no-transcript tag gate
+    # then dropped the <mode>conversation</mode> exit).
+    import server
+    said = "Okay, stop translating now and go back to normal conversation."
+    assert not echoes_instruction(said, server.TRANSLATE_PROMPT)
+    # Unquoted instruction prose still reads as an echo.
+    assert echoes_instruction(
+        "If the audio has no clear words write no speech instead",
+        server.TRANSLATE_PROMPT)

--- a/src/tests/test_stream_parser.py
+++ b/src/tests/test_stream_parser.py
@@ -225,10 +225,51 @@ def test_back_to_back_tags():
     assert tags == [("DELEGATE", "task one"), ("MODE", "translate target=en")]
 
 
-def test_streaming_matches_batch_for_every_split_point_with_tags():
-    batch = run_tags([DELEGATED])
-    for i in range(1, len(DELEGATED)):
-        assert run_tags([DELEGATED[:i], DELEGATED[i:]]) == batch, f"diverged at split {i}"
+def test_tolerant_spacing_still_extracts():
+    # '< delegate >' variants are the model reaching for the tag — firing
+    # the intended action beats suppressing it.
+    spoken, _, tags = run_tags(["###TRANSCRIPT: hi\n", "On it. ",
+                                "< delegate >find X</ delegate >"])
+    assert spoken == ["On it."]
+    assert tags == [("DELEGATE", "find X")]
+
+
+def test_value_may_contain_angle_bracket():
+    # 'flights under <$500' must not wedge the match: the close tag still
+    # terminates the value, and speech resumes after it.
+    spoken, _, tags = run_tags(["###TRANSCRIPT: hi\n", "Sure. ",
+                                "<delegate>flights under <$500</delegate>",
+                                " Give me a sec. "])
+    assert spoken == ["Sure.", "Give me a sec."]
+    assert tags == [("DELEGATE", "flights under <$500")]
+
+
+@pytest.mark.parametrize("markup", [
+    '<delegate task="find X">',   # attribute form
+    "<delegate/> find X",         # self-closing
+    "</delegate> find X",         # orphan close
+], ids=["attribute", "self-closing", "orphan-close"])
+def test_near_miss_markup_is_suppressed_not_spoken(markup):
+    # Names a control tag without being a clean element: model error —
+    # suppress from there on (like ## markup); the task text and anything
+    # after it must never reach TTS, and no action may fire.
+    spoken, _, tags = run_tags(["###TRANSCRIPT: hi\n", "On it. ", markup])
+    assert spoken == ["On it."]
+    assert tags == []
+
+
+@pytest.mark.parametrize("text", [
+    DELEGATED,
+    "###TRANSCRIPT: q\nOk. < delegate >find X</delegate> Done. ",
+    "###TRANSCRIPT: q\nOk. <delegate>a <$5 b</delegate> Done. ",
+    '###TRANSCRIPT: q\nOk. <delegate x="y">TASK never spoken. ',
+    "###TRANSCRIPT: q\nOk. </delegate> TASK never spoken. ",
+    "###TRANSCRIPT: q\nOk. 5 < 10 < 20 holds. <b>b</b>. ",
+], ids=["clean", "tolerant", "inner-lt", "attribute", "orphan", "literal"])
+def test_streaming_matches_batch_for_every_split_point_with_tags(text):
+    batch = run_tags([text])
+    for i in range(1, len(text)):
+        assert run_tags([text[:i], text[i:]]) == batch, f"diverged at split {i}"
 
 
 def test_parser_without_control_tags_is_unchanged():

--- a/src/tests/test_stream_parser.py
+++ b/src/tests/test_stream_parser.py
@@ -272,6 +272,15 @@ def test_streaming_matches_batch_for_every_split_point_with_tags(text):
         assert run_tags([text[:i], text[i:]]) == batch, f"diverged at split {i}"
 
 
+def test_production_filter_knows_every_control_tag():
+    # The filter must ALWAYS be built with every tag name the prompts can
+    # incite: a name it doesn't know is released as speech, so a narrowed
+    # per-mode set would read task text aloud (found in review — modes must
+    # gate acting on tags, never parsing them).
+    import server
+    assert set(n.lower() for n in server.CONTROL_TAGS) == {"delegate", "mode"}
+
+
 def test_parser_without_control_tags_is_unchanged():
     # No control_tags configured → a delegate element is just text; the
     # ##-markup cut still applies to hash markup.

--- a/src/tests/test_transcription_stability.py
+++ b/src/tests/test_transcription_stability.py
@@ -1,0 +1,144 @@
+"""E2E transcript stability: the model must transcribe the CURRENT audio,
+not hallucinate from conversation context — especially on later turns.
+
+Two mechanisms push a long session toward transcript hallucination:
+- every finished turn keeps its raw audio in history, so by turn N the
+  model transcribes against a context holding N audio clips and N of its
+  own '###TRANSCRIPT:' lines — plenty of material to blend or copy;
+- history rotation drops oldest messages, and a dropped user message can
+  orphan its assistant reply, leaving a '###TRANSCRIPT:' line whose audio
+  no longer exists — an in-context example of transcribing from nothing.
+
+Each turn here uses fixtures with marker words unique across the fixture
+set (see benchmarks/fixtures.py), so contamination is detectable: a
+transcript containing another turn's marker was written from history, not
+from the audio. Early turns double as their own controls — the same
+fixtures transcribe cleanly against a near-empty history.
+"""
+
+import fixtures as fx
+import pytest
+from util import audio, norm_words, wer
+
+WER_CLEAN = 0.15
+
+FILLERS = ["filler_color", "filler_pet", "filler_baking",
+           "filler_novel", "filler_jazz", "filler_garden"]
+
+# fixture -> words that appear in no other fixture's reference text.
+MARKERS = {
+    "filler_color": {"turquoise"},
+    "filler_pet": {"biscuit", "retriever"},
+    "filler_baking": {"sourdough", "rosemary"},
+    "filler_novel": {"lisbon", "violin"},
+    "filler_jazz": {"jazz"},
+    "filler_garden": {"basil", "tomatoes"},
+    "capital_france": {"france"},
+    "long_question": {"pronunciation"},
+}
+
+
+def resolved_turn(session, payload, timeout=120):
+    """A turn as the browser drives it: a held (incomplete) utterance is
+    flushed, so every call ends in a terminal answer."""
+    t = session.turn(payload, timeout=timeout)
+    if t.marker == "incomplete":
+        t = session.turn({"type": "flush"}, timeout=timeout)
+    return t
+
+
+def foreign_markers(name: str, transcript: str | None) -> set:
+    """Marker words in the transcript that belong to OTHER fixtures."""
+    words = set(norm_words(transcript or ""))
+    return {m for other, marks in MARKERS.items() if other != name
+            for m in words & marks}
+
+
+def test_transcripts_stay_faithful_as_audio_accumulates(server, session):
+    """Six distinct utterances, then a probe whose fresh-session accuracy
+    the suite already asserts (test_short_question): every turn must
+    transcribe as cleanly late in the session as it does at turn one, with
+    no words borrowed from earlier turns. Rotation must NOT fire here —
+    this test measures accumulation, so history has to actually grow."""
+    dropped_before = server.log().count("dropping")
+    rows, failures = [], []
+    for i, name in enumerate([*FILLERS, "capital_france"]):
+        t = resolved_turn(session, audio(name))
+        w = wer(fx.FIXTURES[name][0], t.transcription or "")
+        rows.append(f"turn {i + 1} {name}: marker={t.marker} wer={w} "
+                    f"heard={t.transcription!r}")
+        if t.marker != "complete":
+            failures.append(f"turn {i + 1} ({name}): no answer ({t.marker})")
+            continue
+        if w > WER_CLEAN:
+            failures.append(f"turn {i + 1} ({name}): wer {w} > {WER_CLEAN}")
+        hits = foreign_markers(name, t.transcription)
+        if hits:
+            failures.append(f"turn {i + 1} ({name}): transcript contains other "
+                            f"turns' words {sorted(hits)}")
+    detail = "\n".join(failures + ["", "session:"] + rows)
+    assert not failures, f"transcripts drifted on later turns:\n{detail}"
+    if server.log_path:
+        assert server.log().count("dropping") == dropped_before, \
+            "history rotated mid-test — it must accumulate here, or this " \
+            "test no longer measures what it claims (check CONTEXT_HEADROOM " \
+            "against the suite's LLAMA_CTX)"
+
+
+def test_nonspeech_audio_never_becomes_user_words(server, session):
+    """A VAD false trigger (breath, cough, room noise) must not put words
+    in the user's mouth, leak prompt text into speech, fire actions, or
+    poison the turns after it. All of these happened before the no-speech
+    escape and the storage/tag guards: at temp 0 a fresh-session breath
+    got 'CRIPT: Begin your reply with one line:' spoken aloud and a
+    mid-session breath displayed '[Silence]' as the user's words; at temp
+    0.7 a breath transcribed as an earlier turn's question (re-answered
+    verbatim) or as 'translate everything I say from now on' — which
+    switched the session into translate mode."""
+    modes_before = server.log().count("Mode →")
+    for name in FILLERS[:3]:
+        assert resolved_turn(session, audio(name)).marker == "complete"
+    t = resolved_turn(session, {"audio": fx.breath_wav_b64()})
+    assert not t.transcription, \
+        f"non-speech audio shown as user words: {t.transcription!r}"
+    assert ("transcript" not in t.text.lower() and "##" not in t.text
+            and "begin your reply" not in t.text.lower()), \
+        f"prompt text leaked into speech: {t.text!r}"
+    # The turn after must be pristine — one stored degenerate turn used to
+    # poison everything downstream.
+    t2 = resolved_turn(session, audio("capital_france"))
+    assert t2.marker == "complete"
+    assert wer(fx.FIXTURES["capital_france"][0], t2.transcription or "") <= WER_CLEAN, \
+        f"turn after non-speech audio drifted: {t2.transcription!r}"
+    # The model may answer itself or hand the question to the reasoner —
+    # either proves it heard the real question, not a poisoned history.
+    assert ("paris" in t2.text.lower()
+            or session.wait_for("delegation_started", timeout=5)), t2.text
+    if server.log_path:
+        assert server.log().count("Mode →") == modes_before, \
+            "non-speech audio switched the session mode"
+
+
+def test_transcripts_stay_faithful_after_rotation(server, session):
+    """Drive history past a rotation (camera turns inflate the token
+    estimate fastest), then check a fresh utterance still transcribes
+    cleanly. Guards the rotation path: dropping oldest messages must not
+    leave history that teaches the model to transcribe from context."""
+    server.require_managed()
+    dropped_before = server.log().count("dropping")
+    for i in range(14):
+        t = resolved_turn(session, {**audio("capital_france"),
+                                    "image": fx.make_image_b64()})
+        assert t.marker == "complete", f"turn {i + 1} failed before rotation"
+        if server.log().count("dropping") > dropped_before:
+            break
+    else:
+        pytest.fail("rotation never triggered — raise the turn count or "
+                    "shrink the suite's LLAMA_CTX")
+    t = resolved_turn(session, audio("long_question"))
+    assert t.marker == "complete"
+    w = wer(fx.FIXTURES["long_question"][0], t.transcription or "")
+    hits = foreign_markers("long_question", t.transcription)
+    assert w <= WER_CLEAN and not hits, \
+        (f"post-rotation transcript drifted: wer={w} "
+         f"borrowed={sorted(hits)} heard={t.transcription!r}")

--- a/src/tests/test_translation.py
+++ b/src/tests/test_translation.py
@@ -1,0 +1,72 @@
+"""Translation-mode e2e: voice-command activation, VAD-only segmenting
+(no smart-turn holds), translate-don't-answer behavior, and both exits —
+the spoken command and the UI escape hatch (set_mode).
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import util  # noqa: E402
+
+
+def switch_by_voice(session, fixture, target, tries=2):
+    """Speak a mode-switch command and wait for the server to confirm it;
+    like delegation tags, the model occasionally confirms without emitting
+    the tag at temp 0.7 — one retry keeps the suite stable, two misses is a
+    real regression."""
+    for _ in range(tries):
+        t = session.turn(util.audio(fixture))
+        if t.marker == "incomplete":
+            # smart-turn held the command (conversation-mode gating):
+            # flush it rather than re-speaking, which would double the
+            # utterance into one merged turn.
+            t = session.turn({"type": "flush"})
+        changed = session.wait_for("mode_changed", timeout=10)
+        if changed and changed.get("mode") == target:
+            return
+    raise AssertionError(
+        f"never switched to {target!r} in {tries} tries — last reply {t.text!r}")
+
+
+def test_translation_renders_speech_instead_of_answering(server, session):
+    server.require_managed()
+    switch_by_voice(session, "cmd_translate", "translate")
+    # 'What is the capital of France?' must come back AS the (restated)
+    # question — an interpreter renders words. Answering it says 'Paris',
+    # which is exactly what must not happen.
+    t = session.turn(util.audio("capital_france"))
+    assert t.marker == "complete", t
+    assert "capital" in t.text.lower()
+    assert "paris" not in t.text.lower(), f"answered instead of translating: {t.text!r}"
+
+
+def test_translation_does_not_hold_incomplete_speech(server, session):
+    server.require_managed()
+    switch_by_voice(session, "cmd_translate", "translate")
+    # This fixture IS held by smart-turn in conversation mode (see
+    # test_incomplete_utterance_is_held) — an interpreter must render it
+    # on the silence window instead of waiting for a complete thought.
+    t = session.turn(util.audio("incomplete_cutoff"))
+    assert t.marker == "complete", t
+    # The rendering carried the actual words (not just a fallback line):
+    # "…I wanted to ask you about…" survives an English→English restate.
+    assert "ask" in t.text.lower(), t.text
+
+
+def test_spoken_command_exits_translation(server, session):
+    server.require_managed()
+    switch_by_voice(session, "cmd_translate", "translate")
+    switch_by_voice(session, "cmd_stop_translate", "conversation")
+    # Back to conversation: questions get answers again.
+    t = session.turn(util.audio("capital_france"))
+    assert t.marker == "complete" and "paris" in t.text.lower()
+
+
+def test_ui_stop_button_exits_translation(server, session):
+    server.require_managed()
+    switch_by_voice(session, "cmd_translate", "translate")
+    session.send({"type": "set_mode", "mode": "conversation"})
+    changed = session.wait_for("mode_changed", timeout=10)
+    assert changed and changed.get("mode") == "conversation"

--- a/src/tests/util.py
+++ b/src/tests/util.py
@@ -86,7 +86,10 @@ class Session:
         return self.collect_turn(timeout)
 
     def collect_turn(self, timeout: float = 90) -> Turn:
-        """Read messages until the current turn reaches a terminal state."""
+        """Read messages until the current turn reaches a terminal state.
+        Every terminal state also sends 'ready', mirroring the browser
+        (which announces idle when playback ends) — the server holds
+        delegation deliveries until it hears it."""
         t = Turn()
         deadline = time.time() + timeout
         while time.time() < deadline:
@@ -104,15 +107,18 @@ class Session:
             elif kind == "turn_incomplete":
                 t.marker = "incomplete"
                 t.p_complete = msg.get("p_complete")
+                self.send({"type": "ready"})
                 return t
             elif kind == "turn_final":
                 t.transcription = msg.get("transcription")
                 t.timings = msg.get("timings", {})
                 if not msg.get("spoke", True):
                     t.marker = "released"
+                    self.send({"type": "ready"})
                     return t
             elif kind == "audio_end":
                 t.marker = "complete"
+                self.send({"type": "ready"})
                 return t
         return t
 

--- a/src/tests/util.py
+++ b/src/tests/util.py
@@ -116,6 +116,16 @@ class Session:
                 return t
         return t
 
+    def wait_for(self, kind: str, timeout: float = 30) -> dict | None:
+        """Read messages until one of type `kind` arrives (others are
+        discarded); None on timeout."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            msg = self.recv(timeout=max(0.1, deadline - time.time()))
+            if msg and msg.get("type") == kind:
+                return msg
+        return None
+
     def send_speech_chunks(self, chunks: list[str], gap_s: float = 1.0) -> None:
         """Stream all but the last chunk like the client does during speech."""
         for seq, chunk in enumerate(chunks[:-1]):


### PR DESCRIPTION
The GPT-Live-inspired feature set in one PR, five commit groups: control-tag foundation → TagFilter hardening → delegation → translation mode → transcript-hallucination fixes.

## Stage 1 — control tags in the response stream

`StreamParser` gains an opt-in `control_tags` list: a complete `<name>value</name>` element in the streamed LLM output is excised into `parser.tags` by a streaming `TagFilter`, never spoken, speech resuming after it. XML beats `###NAME:` lines on live-model recall (**0.667 vs 0.417** on E4B, `benchmarks/tagbench.py`). Guarantees under an all-split-points property test (38 parser tests): half-streamed elements never fire and never reach TTS; unclosed markup at stream end drops; tolerant spacing extracts; values may contain `<`; near-miss markup (`<delegate x=1>`) suppresses speech like the `##` rule; prose `<` passes. The filter is always built from the full tag set — **modes gate acting on a tag, never parsing it** (a narrowed set would speak task text aloud; regression-tested).

## Stage 2 — async delegation to a background reasoner

Ask for web search or current info → spoken acknowledgment + `<delegate>task</delegate>` → the task runs on any OpenAI-compatible endpoint (**OpenRouter default**, `:online` web search, dedicated thread pool) while the conversation continues → the answer arrives as a **proactive server-initiated turn** at the next idle moment, relayed near-verbatim. **Off unless `REASONER_API_KEY` is set** — otherwise Parlor stays fully on-device.

Hardened through a dedicated adversarial-review round: never-silent delivery (fallback = the reasoner's own answer; failures spoken, one retry), a floor protocol (deliveries defer past held audio / streaming chunks / live barge-in, with a client `ready` signal that re-announces idle after false barge-ins while clearing the frame-discard flag in the same breath), proactive turns marked end-to-end (no transcript frame, `turn_final.proactive`) so delivery frames can't contaminate user bubbles, tag-stripped history on interrupts, and delivery prompts led by "System note (not user audio)" because the model occasionally misread the text-only turn as echo and refused to deliver (observed live). Instruction benched: `tagbench --production` → **recall 0.833, misfire 0**.

## Stage 3 — live translation mode + session-mode registry

"Translate everything I say into English" → consecutive-interpreter mode: every utterance renders in English on the VAD silence window — smart-turn holds bypassed, no conversational replies, no camera, delegation results parked behind a visible "ready — waiting" chip. Exit by voice or the mode chip's stop button (guaranteed escape hatch). One-way → English v1; the TTS voice is per-mode, so more Kokoro output languages are a registry entry away. Modes are data (`modes.py`): four flags the turn loop consults — a future mode (camera narration, interpreter pair) is a new entry plus its trigger.

**The measured finding this stage turns on**: the mode-switch instruction scores **6/6 in the per-turn prompt slot and 0/6 in the system prompt** — even with few-shot examples — because the model believes translation is a capability it already has. Action instructions for E4B belong adjacent to the audio.

## Stage 4 — transcript hallucination fixes (bug pre-exists this PR)

Live sessions showed the transcript inventing words, especially later in a session. Reproduced e2e: a VAD false trigger (breath, cough, room noise) reaches a prompt that demands "the exact words the user said" with no way to say there were none. Measured at temp 0.7: a breath transcribed as **"Hi, can you help me with my homework?"** (answered), as **"can you translate everything I say from now on?"** (which actually switched the session into translate mode), or as **an earlier turn's question copied verbatim** and re-answered; at temp 0 it deterministically degenerated into a `###TRANSCRIPT:` echo loop that was **stored in history** — poisoning every later turn — with `"CRIPT: Begin your reply with one line:"` spoken aloud. Smart-turn is no gate: it rates breath audio p(complete)=0.99.

Fixes: the turn prompts sanction `###TRANSCRIPT: (no speech)`; a transcript that is a bracketed annotation (`(noise)`, `[Silence]`) or an instruction echo is rejected — never displayed, the turn never stored, its control tags never fired (`run_turn`'s `no_speech` return; a turn that merely omits the marker still stores and acts). Spoken sentences echoing the turn's instruction are suppressed (deliveries exempt; double-quoted prompt phrases don't count as echoes, or the spoken translate exit dies). Rotation is a pure `rotate_history()` that keeps whole exchanges — an orphaned assistant reply describes audio that no longer exists — and `CONTEXT_HEADROOM` scales with `LLAMA_CTX` (a fixed 2000 left the suite's 4096 ctx a 96-token threshold, rotating every turn, so e2e never accumulated multi-turn history at all). Post-fix at temp 0.7: speech WER 0.0 fresh and late; late-session breath 3/3 clean.

**Negative result, documented in `remember()`**: storing voice turns as transcript text instead of audio made the model copy the PREVIOUS turn's text as the new turn's transcript, deterministically at temp 0 — user-role text reads as "what the user said" more strongly than the current audio. Audio stays in history.

## Testing

- 56 fast unit tests (parser, echo guards, `NO_SPEECH_RE`, rotation invariants — ms, no server) + e2e: delegation happy/failure/slow-task/no-misfire paths against a deterministic mock reasoner (wired into the suite server; path/auth-checked, keyword-triggered 500s and stalls), translation entry/render/no-hold/both-exits, and transcript stability (per-turn WER flat across accumulating turns and past a rotation; a non-speech turn shows no user words, leaks no prompt text, fires no mode switch, and leaves the next turn pristine — **fails on the unfixed code**).
- Delegation/mode-switch asks retry once **with alternate phrasing** — identical audio reproduces the identical tagless completion, so only different words give an independent sample; two misses across two phrasings fails.
- **Full suite: 86 passed, 1 skipped**, all under the delegation-enabled prompt.

## Known limits (documented in code)

- The model reliably delegates what it knows it can't know (current info); for encyclopedic topics it may answer itself despite "search the web" phrasing — and with some history it sometimes delegates encyclopedic questions it should just answer.
- A breath at the very start of a session (no context) can still transcribe as a bare "Hi" and get a greeting back; full elimination needs an acoustic speech gate ahead of the LLM. A mixed turn (real transcript + one echoed sentence) stores the echoed sentence; only all-echo turns are dropped.
- Needs live-mic testing: real non-English speech in translate mode (suite fixtures are Kokoro/English-only), a real OpenRouter key end-to-end, and translate-mode prosody/pacing feel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
