### PR TITLE
Fix five robustness bugs plus zero-risk dedup

### DIFF
--- a/benchmarks/turnbench.py
+++ b/benchmarks/turnbench.py
@@ -50,22 +50,19 @@ import soundfile as sf
 
 import fixtures
 
+# The bench port must be in the env BEFORE parlor.llama is imported — it
+# freezes LLAMA_PORT into a module constant at import time. Not 8081, so a
+# dev server can keep running alongside (setdefault matches tagbench and
+# lets an explicit env override through).
+BENCH_PORT = "8099"
+os.environ.setdefault("LLAMA_PORT", BENCH_PORT)
+
+from parlor.llama import MODELS  # GGUF repo/weights/mmproj per model size
+
 DATASET = "pipecat-ai/smart-turn-data-v3.2-test"
 FILTER_URL = "https://datasets-server.huggingface.co/filter"
 CLIPS_DIR = Path(__file__).parent / "fixtures" / "turn"
 MANIFEST = CLIPS_DIR / "manifest.json"
-
-# GGUF repo, weights, mmproj — all three are Google's official QAT q4_0.
-MODELS = {
-    "e2b": ("google/gemma-4-E2B-it-qat-q4_0-gguf",
-            "gemma-4-E2B_q4_0-it.gguf", "gemma-4-E2B-it-mmproj.gguf"),
-    "e4b": ("google/gemma-4-E4B-it-qat-q4_0-gguf",
-            "gemma-4-E4B_q4_0-it.gguf", "gemma-4-E4B-it-mmproj.gguf"),
-    "12b": ("google/gemma-4-12B-it-qat-q4_0-gguf",
-            "gemma-4-12b-it-qat-q4_0.gguf", "mmproj-gemma-4-12b-it-qat-q4_0.gguf"),
-}
-
-BENCH_PORT = "8099"  # not 8081, so a dev server can keep running alongside
 
 # The two LLM-judged variants server.py used to ship as TURN_MODE=marker and
 # TURN_MODE=two_phase. They live here now: they lost badly enough to be worth
@@ -345,9 +342,8 @@ def main() -> None:
         repo, weights, mmproj = MODELS[args.model]
         os.environ["MODEL_PATH"] = hf_hub_download(repo, weights, local_files_only=True)
         os.environ["MMPROJ_PATH"] = hf_hub_download(repo, mmproj, local_files_only=True)
-        os.environ["LLAMA_PORT"] = BENCH_PORT
 
-    global llama, pipeline, server  # after the env above; llama reads LLAMA_PORT at import
+    global llama, pipeline, server  # deferred — pulls in the whole app
     from parlor import llama, pipeline, server
     detector = None
     if "smart" in modes:

--- a/src/parlor/hf.py
+++ b/src/parlor/hf.py
@@ -1,0 +1,9 @@
+"""HuggingFace downloads with an offline fallback to the local cache."""
+
+
+def download(repo: str, filename: str) -> str:
+    from huggingface_hub import hf_hub_download  # deferred — slow import
+    try:
+        return hf_hub_download(repo, filename)
+    except Exception:  # offline — use the local cache
+        return hf_hub_download(repo, filename, local_files_only=True)

--- a/src/parlor/llama.py
+++ b/src/parlor/llama.py
@@ -9,8 +9,11 @@ import socket
 import subprocess
 import time
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from dotenv import load_dotenv
+
+from parlor import hf
 
 load_dotenv()  # config below is read at import time — .env must apply first
 
@@ -45,15 +48,7 @@ def resolve_model_paths() -> tuple[str, str]:
     if MODEL not in MODELS:
         raise RuntimeError(f"MODEL={MODEL!r} — expected one of {', '.join(MODELS)}")
     repo, gguf, mmproj_file = MODELS[MODEL]
-    from huggingface_hub import hf_hub_download
-    try:
-        model = model or hf_hub_download(repo, gguf)
-        mmproj = mmproj or hf_hub_download(repo, mmproj_file)
-    except Exception:  # offline — use the local cache
-        kw = {"local_files_only": True}
-        model = model or hf_hub_download(repo, gguf, **kw)
-        mmproj = mmproj or hf_hub_download(repo, mmproj_file, **kw)
-    return model, mmproj
+    return model or hf.download(repo, gguf), mmproj or hf.download(repo, mmproj_file)
 
 
 def model_label() -> str:
@@ -66,8 +61,16 @@ def model_label() -> str:
 
 def host_port() -> tuple[str, int]:
     if URL:
-        host, _, port = URL.split("//")[-1].partition(":")
-        return host, int(port or 80)
+        # urlsplit needs the '//' to see an authority; without it a bare
+        # 'myhost:8081' would parse as scheme 'myhost'. Handles a trailing
+        # path too ('http://myhost:8081/v1' is how these URLs are usually
+        # written).
+        u = urlsplit(URL if "//" in URL else "//" + URL)
+        if u.scheme == "https":
+            # Everything here speaks plain HTTPConnection — silently
+            # defaulting an https URL to port 80 would "work" wrongly.
+            raise RuntimeError("LLAMA_SERVER_URL must be http:// (no TLS)")
+        return u.hostname or "127.0.0.1", u.port or 80
     return "127.0.0.1", PORT
 
 
@@ -112,6 +115,11 @@ def start() -> None:
 def stop() -> None:
     if _proc:
         _proc.terminate()
+        try:
+            _proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            _proc.kill()  # a hung llama-server must not outlive us
+            _proc.wait()
 
 
 def _chat_body(messages: list, max_tokens: int, stream: bool) -> dict:

--- a/src/parlor/server.py
+++ b/src/parlor/server.py
@@ -283,8 +283,26 @@ async def websocket_endpoint(ws: WebSocket):
     async def receiver():
         try:
             while True:
-                raw = await ws.receive_text()
-                msg = json.loads(raw)
+                try:
+                    raw = await ws.receive_text()
+                except DISCONNECT_ERRORS:
+                    raise
+                except KeyError:
+                    # A binary frame: Starlette's receive_text() KeyErrors
+                    # on a message with no "text". Our client never sends
+                    # one — skip it, don't die.
+                    print("Ignoring binary client frame")
+                    continue
+                try:
+                    msg = json.loads(raw)
+                except Exception:
+                    msg = None
+                if not isinstance(msg, dict):
+                    # One malformed frame must not end the session (an
+                    # uncaught error here would enqueue None and stop the
+                    # main loop, with the exception never even surfaced).
+                    print(f"Ignoring malformed client message: {raw[:100]!r}")
+                    continue
                 if msg.get("type") == "interrupt":
                     interrupted.set()
                     stream = active.get("stream")

--- a/src/parlor/tts.py
+++ b/src/parlor/tts.py
@@ -6,6 +6,8 @@ import sys
 
 import numpy as np
 
+from parlor import hf
+
 
 def _is_apple_silicon() -> bool:
     return sys.platform == "darwin" and platform.machine() == "arm64"
@@ -41,10 +43,9 @@ class ONNXBackend(TTSBackend):
 
     def __init__(self):
         import kokoro_onnx
-        from huggingface_hub import hf_hub_download
 
-        model_path = hf_hub_download("fastrtc/kokoro-onnx", "kokoro-v1.0.onnx")
-        voices_path = hf_hub_download("fastrtc/kokoro-onnx", "voices-v1.0.bin")
+        model_path = hf.download("fastrtc/kokoro-onnx", "kokoro-v1.0.onnx")
+        voices_path = hf.download("fastrtc/kokoro-onnx", "voices-v1.0.bin")
 
         self._model = kokoro_onnx.Kokoro(model_path, voices_path)
         self.sample_rate = 24000

--- a/src/parlor/turn_detector.py
+++ b/src/parlor/turn_detector.py
@@ -15,6 +15,8 @@ import numpy as np
 import onnxruntime as ort
 from numpy.lib.stride_tricks import sliding_window_view
 
+from parlor import hf
+
 HF_REPO = "pipecat-ai/smart-turn-v3"
 HF_FILE = "smart-turn-v3.2-cpu.onnx"
 SAMPLE_RATE = 16000
@@ -24,11 +26,7 @@ WINDOW_SECONDS = 8  # the model judges the last 8 seconds of the utterance
 class TurnDetector:
     def __init__(self, model_path: str | None = None):
         if not model_path:
-            from huggingface_hub import hf_hub_download
-            try:
-                model_path = hf_hub_download(HF_REPO, HF_FILE)
-            except Exception:  # offline — use the local cache
-                model_path = hf_hub_download(HF_REPO, HF_FILE, local_files_only=True)
+            model_path = hf.download(HF_REPO, HF_FILE)
 
         so = ort.SessionOptions()
         so.execution_mode = ort.ExecutionMode.ORT_SEQUENTIAL

--- a/src/parlor/web/static/app.js
+++ b/src/parlor/web/static/app.js
@@ -10,12 +10,14 @@ let ws, mediaStream, myvad;
 let cameraEnabled = true;
 let audioCtx;
 let state = 'loading';
+let startupFailed = false;
 let ignoreIncomingAudio = false;
 
 // Streaming audio playback state
 let streamSampleRate = 24000;
 let streamNextTime = 0;         // When to schedule next chunk
 let streamSources = [];         // Active AudioBufferSourceNodes
+let streamEnded = false;        // audio_end received — no more chunks coming
 
 // Per-state [glow, glow-dim]. Resolved values, not nested var(): setState
 // writes them into CSS custom properties and the waveform paints with them.
@@ -30,7 +32,6 @@ const STATE_COLORS = {
 let analyser, micSource;
 const BAR_COUNT = 40;
 const BAR_GAP = 3;
-let waveformRAF;
 let ambientPhase = 0;
 
 function initWaveformCanvas() {
@@ -81,7 +82,7 @@ function drawWaveform() {
   }
 
   waveformCtx.globalAlpha = 1;
-  waveformRAF = requestAnimationFrame(drawWaveform);
+  requestAnimationFrame(drawWaveform);
 }
 
 // ── Dynamic glow intensity for speaking state ──
@@ -178,24 +179,44 @@ function wsSend(payload) {
   if (wsOpen()) ws.send(JSON.stringify(payload));
 }
 
+// A reconnect gets a brand-new server conversation — reset the per-turn
+// state with it. Half-resets bite: a surviving ignoreIncomingAudio silently
+// discards the new session's whole first turn, still-scheduled TTS from the
+// dead session keeps playing, and a stuck 'speaking' state pins the VAD at
+// the echo threshold. (State owned by a start function — streamEnded,
+// chunkSeq, preFrames — resets there, not here.)
+function resetSession() {
+  stopPlayback();
+  ignoreIncomingAudio = false;
+  speechActive = false;
+  uttFrames = [];
+  uttSamplesSent = 0;
+  phantomQuiet = 0;
+  bargeWindow = [];
+  framePrefetched = false;
+  serverHoldingAudio = false;
+  currentAssistantEl = null;
+  removePendingUserBubble();
+  delegationChips.forEach(chip => chip.remove());  // tasks died with the server
+  delegationChips.clear();
+  setSessionMode('conversation');
+  clearFlushTimer();
+  if (state !== 'loading') setState('listening');
+}
+
 function connect() {
   ws = new WebSocket(`${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`);
   ws.onopen = () => {
+    if (startupFailed) return;  // a dead page must not read "Connected"
     setStatus('connected', 'Connected');
     if (state !== 'loading') setState('listening');
   };
   ws.onclose = () => {
-    // A reconnect gets a brand-new server conversation — reset per-turn state.
-    framePrefetched = false;
-    serverHoldingAudio = false;
-    removePendingUserBubble();
-    delegationChips.forEach(chip => chip.remove());  // tasks died with the server
-    delegationChips.clear();
-    setSessionMode('conversation');  // a reconnect starts a fresh session
-    clearFlushTimer();
+    resetSession();
     setStatus('disconnected', 'Disconnected');
     setTimeout(connect, 2000);
   };
+  ws.onerror = (e) => console.warn('WebSocket error', e);
   ws.onmessage = ({ data }) => {
     const msg = JSON.parse(data);
     if (msg.type === 'text_delta') {
@@ -233,7 +254,14 @@ function connect() {
         setAssistantMeta((t.ttfa_s ? `first audio ${t.ttfa_s}s · ` : '') + `model ${t.llm_time}s`);
       }
       currentAssistantEl = null;  // the next turn gets its own bubble
-      if (!msg.spoke) goListening();  // no audio will follow
+      if (!msg.spoke) {
+        // No audio will follow — and any still-scheduled audio belongs to
+        // a turn the server abandoned mid-stream (release_client after an
+        // error sends spoke:false even if chunks already played): stop it
+        // rather than announce a free floor over it.
+        stopPlayback();
+        goListening();
+      }
     } else if (msg.type === 'audio_start') {
       if (ignoreIncomingAudio) return;
       streamSampleRate = msg.sample_rate || 24000;
@@ -250,6 +278,8 @@ function connect() {
       }
       const meta = messagesDiv.querySelector('.msg.assistant:last-child .meta');
       if (meta) meta.textContent += ` · tts ${msg.tts_time}s`;
+      streamEnded = true;
+      endTurnIfDrained();
     } else if (msg.type === 'mode_changed') {
       setSessionMode(msg.mode);
     } else if (msg.type === 'delegation_started') {
@@ -421,7 +451,6 @@ async function startCamera() {
   mediaStream = new MediaStream();
   streams.forEach(r => { if (r.status === 'fulfilled') r.value.getTracks().forEach(t => mediaStream.addTrack(t)); });
   if (mediaStream.getVideoTracks().length) video.srcObject = mediaStream;
-  if (!mediaStream.getAudioTracks().length) { cameraEnabled = false; }
 }
 
 function captureFrame() {
@@ -514,7 +543,6 @@ function concatFrames(frames) {
 function sendSpeechChunk(upTo) {
   if (!wsOpen()) return;
   const chunk = concatFrames(uttFrames).subarray(uttSamplesSent, upTo);
-  if (chunk.length < 4800) return; // <300ms — not worth a priming request
   wsSend({ type: 'speech_chunk', seq: chunkSeq++, audio: float32ToWavBase64(chunk) });
   uttSamplesSent = upTo;
 }
@@ -647,6 +675,7 @@ function startStreamPlayback() {
   ensureAudioCtx();
   if (audioCtx.state === 'suspended') audioCtx.resume();
   streamNextTime = audioCtx.currentTime + 0.05; // Small initial buffer
+  streamEnded = false;
   speakingStartedAt = Date.now();
   setState('speaking');
 }
@@ -680,8 +709,19 @@ function queueAudioChunk(base64Pcm) {
   source.onended = () => {
     const idx = streamSources.indexOf(source);
     if (idx !== -1) streamSources.splice(idx, 1);
-    if (streamSources.length === 0 && state === 'speaking') goListening();
+    endTurnIfDrained();
   };
+}
+
+// The turn ends only when the server said no more chunks are coming
+// (audio_end) AND the last scheduled buffer finished playing. An empty
+// buffer alone just means the next sentence hasn't arrived yet — announcing
+// 'ready' early lets a delegation delivery talk over the rest of the reply
+// while the mic treats it as user speech. streamEnded also shields a fresh
+// turn from the previous turn's stopped sources, whose onended fires a tick
+// after startStreamPlayback.
+function endTurnIfDrained() {
+  if (streamEnded && streamSources.length === 0 && state === 'speaking') goListening();
 }
 
 // ── UI ──
@@ -711,6 +751,10 @@ async function init() {
   window.addEventListener('resize', initWaveformCanvas);
 
   await startCamera();
+  if (!mediaStream.getAudioTracks().length) {
+    // Without a mic the VAD would sit silent forever — fail loudly instead.
+    throw new Error('no microphone available (check browser permissions)');
+  }
   connect();
 
   myvad = await vad.MicVAD.new({
@@ -761,4 +805,19 @@ async function init() {
   console.log('VAD initialized and listening');
 }
 
-init();
+// Startup can fail (mic permission denied, VAD assets unreachable) — without
+// this the page sits on 'Loading...' forever with only an unhandled rejection.
+// connect() may already have opened the socket by then, so startupFailed also
+// keeps a late ws.onopen from overwriting the pill with "Connected".
+init().catch(err => {
+  console.error('Startup failed:', err);
+  startupFailed = true;
+  setStatus('disconnected', 'Startup failed');
+  // Label only, not setState: state must stay 'loading' — ws.onopen and
+  // resetSession key on it to keep a half-initialized page out of 'listening'.
+  stateText.textContent = 'Failed';
+  const bubble = addMessage('assistant', '');
+  bubble.textContent =
+    `Could not start: ${err?.message || err}. ` +
+    'Check microphone permissions and network access, then reload the page.';
+});

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,12 @@ from pathlib import Path
 
 import pytest
 
+# Captured BEFORE any parlor import runs load_dotenv() (importing fixtures
+# below pulls in parlor.tts, and test modules import parlor.server during
+# collection): suite overrides must come from the shell, and once .env has
+# been folded into os.environ the two are indistinguishable.
+SHELL_ENV = dict(os.environ)
+
 import fixtures  # resolved via pythonpath = ["benchmarks"] (pyproject.toml)
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -138,12 +144,23 @@ def server(tmp_path_factory, reasoner_mock) -> Server:
     # coin flip and some run always loses one. Production recall at real
     # temperature is tagbench --production's job, not the suite's.
     env = {**os.environ, "PORT": str(TEST_PORT), "LLAMA_PORT": str(TEST_LLAMA_PORT),
-           "LLAMA_CTX": "4096", "MODEL": os.environ.get("MODEL", "e4b"),
-           "TEMPERATURE": os.environ.get("TEMPERATURE", "0"),
+           "LLAMA_CTX": "4096", "MODEL": SHELL_ENV.get("MODEL", "e4b"),
+           "TEMPERATURE": SHELL_ENV.get("TEMPERATURE", "0"),
            "REASONER_BASE_URL": f"http://127.0.0.1:{TEST_REASONER_PORT}/v1",
            "REASONER_API_KEY": "test-key", "REASONER_MODEL": "mock-model",
            "REASONER_TIMEOUT": "20"}
-    env.pop("LLAMA_SERVER_URL", None)
+    # A developer's .env must not change what the suite measures: every
+    # model/backend key is taken from SHELL_ENV (deliberate override) or
+    # pinned, never from .env — which by now is inside os.environ and
+    # would otherwise leak through the spread above. Set to "" rather
+    # than popped: the child runs load_dotenv() itself, which fills in
+    # missing keys from .env but never overrides an existing (even
+    # empty) one. LLAMA_SERVER_URL is cleared unconditionally — the
+    # suite owns its server topology (external servers go through
+    # PARLOR_TEST_URL instead).
+    for k in ("MODEL_PATH", "MMPROJ_PATH", "KOKORO_ONNX"):
+        env[k] = SHELL_ENV.get(k, "")
+    env["LLAMA_SERVER_URL"] = ""
     with open(log_path, "w") as log:
         proc = subprocess.Popen([sys.executable, "-m", "parlor.server"], cwd=ROOT,
                                 env=env, stdout=log, stderr=subprocess.STDOUT)


### PR DESCRIPTION
Bug-fix PR from the simplification/robustness audit — behavior fixes and zero-risk dedup only; structural refactors (Session extraction, turn-ID protocol, test markers) are deliberately left for follow-ups.

## Client (app.js)

- **`ready` is sent only after `audio_end`**, not whenever the playback buffer momentarily drains. Chunks arrive one TTS'd sentence at a time, so a short first sentence routinely played out before the next chunk was ready — the early `ready` zeroed the server's `playing_since` and let a queued delegation delivery talk over the still-streaming reply, while the dropped VAD threshold let TTS echo be captured as user speech. A `streamEnded` flag gates both transition sites (`endTurnIfDrained()`); it also shields a fresh turn from the previous turn's stopped sources. `tests/util.py` (the protocol reference client) already did this correctly — the browser was the outlier.
- **`turn_final {spoke:false}` stops still-scheduled audio** — the server sends it after abandoning a turn mid-stream (`release_client` on error), and this was the last remaining path that announced a free floor over audible TTS.
- **`ws.onclose` fully resets per-turn state** via one `resetSession()`. Previously a surviving `ignoreIncomingAudio` silently discarded the entire first turn after a reconnect, TTS from the dead session kept playing, and a stuck `speaking` state pinned the VAD at the echo threshold. Also adds `ws.onerror` logging.
- **Startup failures surface in the UI** (mic denied, VAD CDN unreachable, no audio track) instead of "Loading..." forever with an unhandled rejection; a late `ws.onopen` can't overwrite the failure pill. The no-mic soft-disable in `startCamera` (which wrongly gated the *camera* on *audio* tracks, and is dead now that init hard-fails) is removed.
- Dead code: the unreachable `<4800` guard in `sendSpeechChunk`, the never-read `waveformRAF`.

## Server

- **One malformed, non-dict, or binary WebSocket frame no longer kills the session.** The receiver task previously died on any `json.loads` failure (and Starlette's `receive_text` KeyErrors on binary frames), enqueued `None`, and ended the main loop — with the exception swallowed as an unretrieved task exception.
- **`host_port()` parses `LLAMA_SERVER_URL` with `urlsplit`** — `http://host:8081/v1` (the conventional form, documented in the README) used to crash on `int("8081/v1")`. Bare `host:port` still works; `https://` is rejected outright instead of silently probing port 80 with plain HTTP.
- **`llama.stop()`** terminates, waits 10s, then kills — a hung llama-server no longer outlives the app.

## Tests

- **conftest's suite pins now hold.** All model/backend overrides (`MODEL`, `TEMPERATURE`, `MODEL_PATH`, `MMPROJ_PATH`, `KOKORO_ONNX`) are read from a `SHELL_ENV` snapshot captured before any parlor import runs `load_dotenv()`, and pinned to `""` in the child env otherwise — popping is insufficient because the child re-runs `load_dotenv()` and resurrects popped keys from `.env`. Previously a developer's `.env` could silently swap the model, temperature, or TTS backend (and with it the synthesized fixture audio, hence turn-classifier outcomes) under a suite whose comments claimed those were pinned. Shell overrides (`MODEL=e2b uv run pytest`) still work.

## Dedup

- `parlor/hf.py`: one `download()` with the offline-cache fallback, replacing three inline copies — and adding the fallback the ONNX TTS path lacked.
- `turnbench` imports `MODELS` from `parlor.llama` instead of a byte-identical copy. `LLAMA_PORT` is set **before** that import (`parlor.llama` freezes it into a constant at import time); review caught that the naive import ran the benchmark's llama-server on the dev port 8081.

## Verification

- `node --check` on app.js; `py_compile` on all touched Python.
- Fast suite (`tests/test_stream_parser.py tests/test_history.py`, no model needed): **56 passed**.
- `host_port()` verified against `http://host:8081/v1`, bare `host:9000`, `http://localhost:8081`, and `https://` (rejected).
- turnbench import verified to freeze `llama.PORT = 8099` (and to honor an explicit `LLAMA_PORT` override).
- The e2e suite (31 tests) needs a real llama.cpp + model download and was **not** run here — worth a run before merge.
- The `streamEnded` interplay was adversarially reviewed across all orderings (audio_end before/after last onended, barge-in mid-stream, back-to-back turns, server error mid-stream, delegation delivery) by a separate review pass; two review rounds (correctness + simplification) are folded into this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)