### PR TITLE
Reasoner + llama.cpp hardening, config docs, camera experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ The obvious answer: run everything on-device, eliminating any server cost. Six m
 
 Google just released a super capable small model that I can run on my M3 Pro in real-time, with vision too! Sure you can't do agentic coding with this, but it is a game-changer for people learning a new language. Imagine a few years from now that people can run this locally on their phones. They can point their camera at objects and talk about them. And this model is multi-lingual, so people can always fallback to their native language if they want. This is essentially what OpenAI demoed a few years ago.
 
+## AI disclosure
+
+This software is developed with strong assistance from Claude and with humans leading the ideas, testing, and debugging. We say this openly because it shaped how the project was built. If you are not happy with AI-developed code, this software is not for you.
+
 ## How it works
 
 ```
@@ -24,30 +28,31 @@ Browser (mic + camera)
     │  WebSocket (audio PCM + JPEG frames)
     ▼
 FastAPI server
-    ├── Gemma 4 E4B via llama.cpp (QAT q4_0)  →  understands speech + vision
-    └── Kokoro TTS (MLX on Mac, ONNX on Linux)  →  speaks back
+    ├── smart-turn-v3 (~20ms)                   →  did you finish your thought?
+    ├── Gemma 4 E4B via llama.cpp (QAT q4_0)    →  hears + sees, streams the reply
+    │     └── action head (same model, JSON)    →  timers · modes · research
+    ├── Kokoro TTS (MLX on Mac, ONNX on Linux)  →  speaks sentence-by-sentence
+    └── background reasoner (optional)          →  frontier model for web research
     │
-    │  WebSocket (streamed audio chunks)
+    │  WebSocket (transcript + streamed audio chunks)
     ▼
 Browser (playback + transcript)
 ```
 
-- **Voice Activity Detection** in the browser ([Silero VAD](https://github.com/ricky0123/vad)). Hands-free, no push-to-talk, with a short 200ms silence cutoff for fast turn-taking.
-- **Turn-completeness filtering.** Pipecat's [smart-turn-v3](https://huggingface.co/pipecat-ai/smart-turn-v3) audio classifier (~20ms on CPU) judges whether you finished your thought before the LLM answers — if you were cut off or paused to think, it stays quiet and lets you continue. If you then stay silent, the held audio is flushed to the model, which either answers it or warmly asks you to finish.
-- **Streaming decode → TTS.** The reply opens with a one-line transcript of what you said (committing to it first measurably improves both transcript and response accuracy, and it appears on screen immediately), then the response is spoken sentence-by-sentence while the model is still generating.
-- **Speculative prefill during speech.** The camera frame is sent the moment you start speaking, and your speech itself streams to the server in ~3s chunks — both are pushed through llama.cpp's prompt cache while you're still talking, so at the end of a long question almost everything is already processed.
-- **Barge-in.** Interrupt the AI mid-sentence by speaking; generation is aborted server-side. Echo is handled without the browser's echo canceller (which muffles both the TTS voice and your barge-in on macOS): a sustained-speech gate plus a prompt rule — or just wear headphones.
-- **Background research delegation** (optional). Ask something that needs web search or real reasoning — "find the best pizza in Rome right now" — and the local model hands the task to a frontier model on any OpenAI-compatible endpoint (OpenRouter by default, with web search), keeps the conversation going, and speaks the answer when it comes back. Off unless `REASONER_API_KEY` is set; without it Parlor stays fully on-device.
-- **Live translation mode.** Say "translate everything I say into English" and Parlor becomes a consecutive interpreter: each utterance is rendered in English after a short silence window (no turn-completeness holds, no conversational replies), in any language Gemma understands. Say "stop translating" — or hit the stop chip — to return to conversation. One-way into English for now; the TTS voice is per-mode, so more Kokoro output languages are a config away.
-- **Just-listen mode.** Say "just listen for a while, I want to think out loud" and Parlor becomes a silent scribe: every utterance is transcribed on screen but nothing is spoken back — no replies, no holds — until you address it again ("okay, what do you think?") or hit the stop chip.
-- **Timers.** "Set a timer for three minutes for the pasta" — the model confirms naturally; the server owns the clock and, when it goes off, the model announces it out loud (waiting out anything currently playing, in any mode). A countdown chip with a cancel button tracks it in the transcript. Measured first (`benchmarks/timerprobe.py`): without this machinery the model promises timers 6/6 but announces them 1/6 even when told how much time passed — a turn-based model can't ring into silence, so the server must own the clock.
-- **A decoupled action decider.** The spoken reply is pure speech — no control markup ever rides it. What the user *asked for* (a timer, a mode switch, research) is decided by a separate grammar-forced JSON request over the same llama.cpp prefix cache, at temperature 0, with the model's own confirmation as evidence, while TTS is already playing. Measured against in-band control tags (`benchmarks/archbench.py`): recall 1.0 vs 0.955, where the tags' miss is the worst voice-assistant failure — a spoken promise ("I will be quiet") the server never keeps. It also makes leaks structurally impossible and durations multilingual (the model outputs integer seconds).
-- **A sense of elapsed time.** After a real gap, the next turn tells the model how much quiet preceded it ("about 2 minutes"), delegation deliveries say how long the research took, and the system prompt anchors when the session started — so "how long was I gone?" gets a real answer.
+- **Background research** (optional). "Find the best pizza in Rome right now" hands the task to a frontier model on any OpenAI-compatible endpoint (OpenRouter + web search by default) while the conversation continues; the answer is spoken when it arrives. Off unless `REASONER_API_KEY` is set — without it Parlor stays fully on-device.
+- **Hands-free turn-taking.** Browser-side [Silero VAD](https://github.com/ricky0123/vad) with a ~200ms silence cutoff — no push-to-talk. Pipecat's [smart-turn-v3](https://huggingface.co/pipecat-ai/smart-turn-v3) then judges whether you actually finished your thought: mid-thought pauses are held silently until you continue, or answered once you stay quiet.
+- **Everything streams.** The reply opens with a transcript of what was heard (on screen immediately — committing to it first measurably improves accuracy), then is spoken sentence-by-sentence while still generating. Your camera frame and speech are pushed through llama.cpp's prompt cache while you're still talking, so even long questions start answering almost instantly.
+- **Barge-in.** Speak over the AI to interrupt it; generation is aborted server-side. Echo is handled without the browser's echo canceller — or just wear headphones.
+- **Actions never ride the speech.** Timers, mode switches, and research requests are decided by a separate grammar-forced JSON request over the same prompt cache, hidden under TTS playback. The spoken reply stays pure speech, so control markup can never leak into TTS and a promise made aloud is always kept (recall 1.0 vs 0.955 for in-band tags — `benchmarks/archbench.py`).
+- **Timers.** "Set a timer for three minutes for the pasta" — the server owns the clock (a turn-based model can't ring into silence — `benchmarks/timerprobe.py`), the model announces the ring out loud in any mode, and a countdown chip with a cancel button tracks it.
+- **Live translation mode.** "Translate everything I say into English" turns Parlor into a consecutive interpreter: each utterance rendered after a short silence, no conversational replies, in any language Gemma understands — until you say "stop translating" or hit the stop chip.
+- **Just-listen mode.** "Just listen for a while, I want to think out loud" makes it a silent scribe: every utterance transcribed on screen, nothing spoken back, until you address it again.
+- **A sense of time.** The model is told how much quiet preceded a turn, how long research took, and when the session started — so "how long was I gone?" gets a real answer.
 
 ## Requirements
 
 - Python 3.12+
-- [llama.cpp](https://github.com/ggml-org/llama.cpp) (`brew install llama.cpp` on macOS; other platforms: [install guide](https://github.com/ggml-org/llama.cpp/blob/master/docs/install.md))
+- [llama.cpp](https://github.com/ggml-org/llama.cpp) (`brew install llama.cpp` on macOS; other platforms: [install guide](https://github.com/ggml-org/llama.cpp/blob/master/docs/install.md)). Needs build b9503 (June 2026) or newer — older builds lack Gemma 4 audio or crash loading its mmproj
 - macOS with Apple Silicon, or Linux with a supported GPU
 - ~6 GB free RAM for the default E4B model (`MODEL=e2b` fits in ~4 GB)
 
@@ -71,22 +76,17 @@ Models are downloaded automatically on first run (~5.7 GB for Gemma 4 E4B QAT + 
 
 ## Configuration
 
+Set these in your shell or a `.env` at the repo root. The common ones:
+
 | Variable           | Default                        | Description                                    |
 | ------------------ | ------------------------------ | ---------------------------------------------- |
 | `MODEL`            | `e4b`                          | Gemma 4 size: `e2b` (fastest), `e4b` (better answers, ~1.8x e2b latency), `12b` (needs ~8GB) |
-| `MODEL_PATH`       | auto-download from HuggingFace | Path to a local Gemma 4 `.gguf` file (overrides `MODEL`) |
-| `MMPROJ_PATH`      | auto-download from HuggingFace | Path to the matching `mmproj` `.gguf` (audio + vision encoders) |
 | `PORT`             | `8000`                         | Server port                                    |
-| `TEMPERATURE`      | `0.7`                          | Sampling temperature (0 = deterministic)       |
-| `LLAMA_CTX`        | `16384`                        | llama.cpp context size. The server drops the oldest exchanges shortly before it fills |
-| `TIME_NOTE_MIN_S`  | `120`                          | Seconds of quiet before a turn carries an elapsed-time note |
-| `LLAMA_PORT`       | `8081`                         | Port for the spawned llama-server              |
-| `LLAMA_SERVER_URL` | (spawn our own)                | Use an already-running llama-server instead    |
-| `REASONER_API_KEY` | (unset — delegation off)       | API key for the background reasoner endpoint   |
+| `REASONER_API_KEY` | (unset — research off)         | API key enabling background research           |
 | `REASONER_BASE_URL`| `https://openrouter.ai/api/v1` | Any OpenAI-compatible chat endpoint            |
-| `REASONER_MODEL`   | `anthropic/claude-sonnet-4.5`  | Model the endpoint should run                  |
-| `REASONER_WEB_SEARCH` | `1`                         | On OpenRouter, append `:online` for web search |
-| `REASONER_TIMEOUT` | `90`                           | Seconds before a background task fails         |
+| `REASONER_MODEL`   | `openai/gpt-5.6-luna`          | Model the endpoint should run                  |
+
+The full list — local model paths, llama.cpp tuning, TTS backend, test hooks — is in [docs/configuration.md](docs/configuration.md).
 
 ## Performance (Apple M3 Pro)
 
@@ -133,7 +133,7 @@ src/parlor/
 ├── pipeline.py            # Streaming turn pipeline (decode → sentences → TTS)
 ├── actions.py             # Action decider (grammar-forced JSON: timers, modes, research)
 ├── reasoner.py            # Background research delegation (OpenAI-compatible)
-├── modes.py               # Session modes (conversation, translate)
+├── modes.py               # Session modes (conversation, translate, listen)
 ├── turn_detector.py       # smart-turn-v3 end-of-turn classifier
 ├── tts.py                 # Platform-aware TTS (MLX on Mac, ONNX on Linux)
 └── web/                   # Frontend (markup, styles, app logic: VAD, camera, playback)
@@ -142,7 +142,9 @@ benchmarks/
 ├── bench.py               # End-to-end latency benchmark
 ├── fixtures.py            # Spoken-audio fixtures (synthesized locally)
 ├── compare.py             # Diff two benchmark result files
-└── turnbench.py           # Turn-detection accuracy benchmark
+├── turnbench.py           # Turn-detection accuracy benchmark
+├── archbench.py           # In-band control tags vs decoupled action head
+└── timerprobe.py          # Why the server owns the timer clock
 ```
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Browser (playback + transcript)
 ## Requirements
 
 - Python 3.12+
-- [llama.cpp](https://github.com/ggml-org/llama.cpp) (`brew install llama.cpp` on macOS; other platforms: [install guide](https://github.com/ggml-org/llama.cpp/blob/master/docs/install.md)). Needs build b9503 (June 2026) or newer — older builds lack Gemma 4 audio or crash loading its mmproj
+- [llama.cpp](https://github.com/ggml-org/llama.cpp) (`brew install llama.cpp` on macOS; other platforms: [install guide](https://github.com/ggml-org/llama.cpp/blob/master/docs/install.md)). Needs build b9503 (June 2026) or newer, b9512 for `MODEL=12b` — older builds lack Gemma 4 audio or crash loading its mmproj
 - macOS with Apple Silicon, or Linux with a supported GPU
 - ~6 GB free RAM for the default E4B model (`MODEL=e2b` fits in ~4 GB)
 
@@ -144,6 +144,7 @@ benchmarks/
 ├── compare.py             # Diff two benchmark result files
 ├── turnbench.py           # Turn-detection accuracy benchmark
 ├── archbench.py           # In-band control tags vs decoupled action head
+├── camerabench.py         # Attach-every-turn vs camera-as-tool-call
 └── timerprobe.py          # Why the server owns the timer clock
 ```
 

--- a/benchmarks/camerabench.py
+++ b/benchmarks/camerabench.py
@@ -1,0 +1,331 @@
+"""Camera-architecture benchmark: attach the frame every turn (production)
+vs fetch it on demand — the "camera as a tool call" question.
+
+Production attaches the client's camera frame to every audio turn and
+speculatively prefills it while the user is still talking, so the frame
+costs no perceived latency — but it does cost GPU work per frame and
+~image-sized context per turn, forever, in history. The alternative is to
+treat the camera like a tool: the decoupled action head reports whether
+the turn NEEDS the frame, and only then does a request carry it.
+
+    Arch A (attach): production — frame + audio in one request, frame
+                     primed during speech. The baseline.
+    Arch B (pre):    head judges the audio FIRST (needs_camera field),
+                     then the speech request attaches the frame only on
+                     "yes". The head's wall time lands BEFORE first audio
+                     on EVERY turn — that is its structural price.
+    Arch C (post):   production's speak-first shape — the reply streams
+                     with no frame, THEN the head decides; on "yes" a
+                     follow-up turn with the frame answers for real. Chat
+                     turns pay nothing, vision turns pay a second full
+                     turn — and the first (blind) reply may hallucinate
+                     a scene it never saw, which is judged here too.
+
+Per arch: cam_recall (head wants the frame on vision questions),
+cam_misfire (wants it on plain chat), answer_ok (the final spoken reply
+names what the fixture scene actually shows), blind_hallucination (C's
+first reply invents scene content), and the wall-time components a user
+would feel. frame_tokens reports what one JPEG costs in context, from
+llama-server's own usage counts.
+
+Measured (e4b, M3 Pro, 2026-08-02 — results/camerabench.json): keep A.
+A frame costs 50 context tokens (not the ~300 pipeline.py estimates) and
+~600ms of prime GPU hidden under speech; A answers 1.0 at 1.55s median.
+B decides perfectly (recall 1.0, misfire 0.0) but its head runs before
+speech can start, adding ~2.2s to EVERY turn — vision answers land at
+4.2s. C is structurally broken: the blind reply either denies having
+eyes or confidently hallucinates ("the round shape is blue", "a picture
+of a cat"), the user hears it, and the head then reads that answered
+reply as evidence no frame is needed — recall 0.0, answer_ok 0.375. The
+speak-first shape that makes timers cheap is exactly what kills
+on-demand vision: an unanswerable question never survives to the head.
+
+    uv run python benchmarks/camerabench.py --repeat 2 \
+        --out benchmarks/results/camerabench.json
+
+Runs its own llama-server on port 8099 (like archbench); WAVs cache in
+fixtures/tagbench/.
+"""
+
+import argparse
+import http.client
+import json
+import os
+import time
+from pathlib import Path
+
+os.environ.setdefault("LLAMA_PORT", "8099")
+
+import fixtures  # noqa: E402
+from tagbench import ensure_fixtures  # noqa: E402
+from parlor import actions  # noqa: E402
+from parlor import llama  # noqa: E402
+from parlor import server  # noqa: E402
+from parlor.pipeline import audio_part, image_part, text_part  # noqa: E402
+
+# ── cases ─────────────────────────────────────────────────────────────────
+# The fixture scene (fixtures.make_image_b64 "day"): blue sky over a green
+# field with a red sun-like circle. expected: (needs_camera, answer
+# keywords — any-of, checked on the final spoken reply; [] = don't judge).
+SCENE_WORDS = ["sky", "field", "sun", "green", "blue", "red", "circle",
+               "landscape", "grass"]
+CASES = {
+    "cam_describe": "Can you describe what you can see right now?",
+    "cam_color": "Look at my camera. What color is the round shape?",
+    "cam_showing": "What am I showing you right now?",
+    "cam_capital": "What is the capital of France?",
+    "cam_jazz": "Lately I have been listening to a lot of jazz piano "
+                "records in the evening.",
+    # Trap: visual language with nothing to look at.
+    "cam_sunset_trap": "I saw a beautiful sunset yesterday while walking "
+                       "home from the station.",
+}
+EXPECTED: dict[str, tuple[bool, list[str]]] = {
+    "cam_describe": (True, SCENE_WORDS),
+    "cam_color": (True, ["red"]),
+    "cam_showing": (True, SCENE_WORDS),
+    "cam_capital": (False, ["paris"]),
+    "cam_jazz": (False, []),
+    "cam_sunset_trap": (False, []),
+}
+
+SYSTEM = server.SYSTEM_PROMPT + server.CAPABILITY_NOTE + server.RESEARCH_NOTE
+RESPOND_CAM = server.RESPOND_PROMPT.format(
+    camera=" Mention what you see on their camera if relevant.")
+RESPOND_PLAIN = server.RESPOND_PROMPT.format(camera="")
+
+# The production head prompt + schema, extended with one field: does this
+# turn need the camera? Bench-local — this is exactly what would move into
+# actions.py if an on-demand arch won.
+CAM_CLAUSE = (
+    " camera: true ONLY if answering requires looking at the user's "
+    "camera right now — they ask what you see, or refer to something "
+    "they are currently showing, holding, or pointing at; talking ABOUT "
+    "sights or scenery is not showing you anything, so camera is false."
+)
+HEAD_PROMPT = actions._HEAD_COMMON.format(
+    mode_clause=actions._MODE_CLAUSES["conversation"]) + CAM_CLAUSE
+HEAD_SCHEMA = {
+    **actions.HEAD_SCHEMA,
+    "properties": {**actions.HEAD_SCHEMA["properties"],
+                   "camera": {"type": "boolean"}},
+    "required": actions.HEAD_SCHEMA["required"] + ["camera"],
+}
+
+
+def chat(messages: list, *, max_tokens: int = 256,
+         temperature: float | None = None,
+         json_schema: dict | None = None) -> tuple[str, int]:
+    """Direct llama-server call; returns (content, prompt_tokens)."""
+    body: dict = {"messages": messages, "max_tokens": max_tokens,
+                  "cache_prompt": True,
+                  "chat_template_kwargs": {"enable_thinking": False}}
+    body["temperature"] = llama.TEMPERATURE if temperature is None else temperature
+    if json_schema:
+        body["response_format"] = {"type": "json_schema",
+                                   "json_schema": {"schema": json_schema}}
+    conn = http.client.HTTPConnection(*llama.host_port(), timeout=300)
+    conn.request("POST", "/v1/chat/completions", json.dumps(body),
+                 {"Content-Type": "application/json"})
+    data = json.loads(conn.getresponse().read())
+    conn.close()
+    if "error" in data:
+        raise RuntimeError(f"llama-server: {data['error']}")
+    return (data["choices"][0]["message"].get("content") or "",
+            (data.get("usage") or {}).get("prompt_tokens") or 0)
+
+
+def prime(messages: list) -> int:
+    """Production's cache priming (runs during user speech, so its wall
+    time is GPU cost, not perceived latency). Returns its wall ms."""
+    t0 = time.time()
+    chat(messages, max_tokens=1)
+    return round((time.time() - t0) * 1000)
+
+
+def run_head(prefix: list) -> tuple[dict, int]:
+    t0 = time.time()
+    raw, _ = chat(prefix + [{"role": "user", "content": HEAD_PROMPT}],
+                  max_tokens=64, temperature=0.0, json_schema=HEAD_SCHEMA)
+    ms = round((time.time() - t0) * 1000)
+    try:
+        return json.loads(raw), ms
+    except ValueError:
+        return {}, ms
+
+
+def spoken(reply: str) -> str:
+    """Everything after the transcript line — what TTS would say."""
+    return reply.split("\n", 1)[1] if "\n" in reply else reply
+
+
+# Each runner returns (wants_camera, answer_text, blind_text|None, extra).
+# answer_text is the reply the user ultimately hears for the question;
+# blind_text is C's first no-frame reply on turns the head then escalated.
+
+def run_arch_a(wav: str, img: str) -> tuple[bool, str, None, dict]:
+    user = [image_part(img), audio_part(wav), text_part(RESPOND_CAM)]
+    prime_ms = prime([{"role": "system", "content": SYSTEM},
+                      {"role": "user", "content": [image_part(img), audio_part(wav)]}])
+    t0 = time.time()
+    reply, pt = chat([{"role": "system", "content": SYSTEM},
+                      {"role": "user", "content": user}])
+    return True, spoken(reply), None, {
+        "turn_ms": round((time.time() - t0) * 1000),
+        "prime_ms": prime_ms, "prompt_tokens": pt, "raw": reply}
+
+
+def run_arch_b(wav: str, img: str) -> tuple[bool, str, None, dict]:
+    base = [{"role": "system", "content": SYSTEM}]
+    prime_ms = prime(base + [{"role": "user", "content": [audio_part(wav)]}])
+    # decide_before shape: head prompt rides the same user message as the
+    # audio, extending the primed prefix.
+    t0 = time.time()
+    raw, _ = chat(base + [{"role": "user",
+                           "content": [audio_part(wav), text_part(HEAD_PROMPT)]}],
+                  max_tokens=64, temperature=0.0, json_schema=HEAD_SCHEMA)
+    head_ms = round((time.time() - t0) * 1000)
+    try:
+        wants = bool(json.loads(raw).get("camera"))
+    except ValueError:
+        wants = False
+    content = ([image_part(img), audio_part(wav), text_part(RESPOND_CAM)]
+               if wants else [audio_part(wav), text_part(RESPOND_PLAIN)])
+    t0 = time.time()
+    reply, pt = chat(base + [{"role": "user", "content": content}])
+    return wants, spoken(reply), None, {
+        "head_ms": head_ms, "turn_ms": round((time.time() - t0) * 1000),
+        "prime_ms": prime_ms, "prompt_tokens": pt, "raw": reply}
+
+
+def run_arch_c(wav: str, img: str) -> tuple[bool, str, str | None, dict]:
+    base = [{"role": "system", "content": SYSTEM}]
+    prime_ms = prime(base + [{"role": "user", "content": [audio_part(wav)]}])
+    speech = base + [{"role": "user",
+                      "content": [audio_part(wav), text_part(RESPOND_PLAIN)]}]
+    t0 = time.time()
+    reply, pt = chat(speech)
+    turn_ms = round((time.time() - t0) * 1000)
+    prefix = speech + [{"role": "assistant", "content": reply}]
+    head, head_ms = run_head(prefix)
+    wants = bool(head.get("camera"))
+    extra = {"turn_ms": turn_ms, "head_ms": head_ms, "prime_ms": prime_ms,
+             "prompt_tokens": pt, "raw": reply}
+    if not wants:
+        return False, spoken(reply), None, extra
+    t0 = time.time()
+    followup = ("System note (not user audio): here is the user's camera "
+                "frame. Now answer their question, looking at it. 1-4 "
+                "short sentences, spoken aloud.")
+    reply2, pt2 = chat(prefix + [{"role": "user",
+                                  "content": [image_part(img), text_part(followup)]}])
+    extra.update({"turn2_ms": round((time.time() - t0) * 1000),
+                  "prompt_tokens2": pt2, "raw2": reply2})
+    return True, spoken(reply2), spoken(reply), extra
+
+
+RUNNERS = {"A_attach": run_arch_a, "B_pre": run_arch_b, "C_post": run_arch_c}
+
+
+def judge(name: str, wants: bool, answer: str, blind: str | None) -> dict:
+    needs, keywords = EXPECTED[name]
+    answer_l = answer.lower()
+    return {
+        "case": name, "needs_camera": needs, "wants_camera": wants,
+        "cam_hit": wants == needs,
+        "answer_ok": (any(k in answer_l for k in keywords)
+                      if keywords else None),
+        # C only: the blind first reply claims scene content it never saw.
+        "blind_hallucination": (any(k in blind.lower() for k in SCENE_WORDS)
+                               if blind is not None else None),
+        "blind": blind,
+    }
+
+
+def measure_frame_tokens(wav: str, img: str) -> int:
+    """What one JPEG frame costs in context, from llama's own counts."""
+    _, with_img = chat([{"role": "system", "content": SYSTEM},
+                        {"role": "user", "content": [image_part(img), audio_part(wav),
+                                                     text_part(RESPOND_CAM)]}],
+                       max_tokens=1)
+    _, without = chat([{"role": "system", "content": SYSTEM},
+                       {"role": "user", "content": [audio_part(wav),
+                                                    text_part(RESPOND_CAM)]}],
+                      max_tokens=1)
+    return with_img - without
+
+
+def score(results: list[dict]) -> dict:
+    pos = [r for r in results if r["needs_camera"]]
+    neg = [r for r in results if not r["needs_camera"]]
+    judged = [r for r in results if r["answer_ok"] is not None]
+    out = {
+        "cam_recall": round(sum(r["wants_camera"] for r in pos) / len(pos), 3),
+        "cam_misfire": round(sum(r["wants_camera"] for r in neg) / len(neg), 3),
+        "answer_ok": round(sum(r["answer_ok"] for r in judged) / len(judged), 3),
+        "n": len(results),
+    }
+    blind = [r for r in results if r["blind_hallucination"] is not None]
+    if blind:
+        out["blind_hallucination"] = round(
+            sum(r["blind_hallucination"] for r in blind) / len(blind), 3)
+    for key in ("turn_ms", "head_ms", "turn2_ms", "prime_ms"):
+        vals = sorted(r[key] for r in results if key in r)
+        if vals:
+            out[f"{key}_p50"] = vals[len(vals) // 2]
+    # What the user waits on a VISION turn, per arch: A = turn (frame was
+    # primed); B = head + turn; C = turn1 + head + turn2.
+    vis = [r for r in results if r["needs_camera"]]
+    waits = [r.get("head_ms", 0) + r.get("turn_ms", 0) + r.get("turn2_ms", 0)
+             for r in vis]
+    if waits:
+        waits.sort()
+        out["vision_wait_ms_p50"] = waits[len(waits) // 2]
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repeat", type=int, default=2)
+    ap.add_argument("--archs", default="A_attach,B_pre,C_post",
+                    help=f"comma-separated subset of {', '.join(RUNNERS)}")
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+
+    wavs = ensure_fixtures(CASES)
+    img = fixtures.make_image_b64(scene="day")
+    llama.start()
+    try:
+        out = {"model": llama.MODEL, "speech_temperature": llama.TEMPERATURE,
+               "repeat": args.repeat,
+               "frame_tokens": measure_frame_tokens(wavs["cam_capital"], img),
+               "archs": {}}
+        print(f"One frame costs {out['frame_tokens']} context tokens\n")
+        for label in args.archs.split(","):
+            runner = RUNNERS[label]
+            results = []
+            for name, wav in wavs.items():
+                for _ in range(args.repeat):
+                    t0 = time.time()
+                    wants, answer, blind, extra = runner(wav, img)
+                    r = judge(name, wants, answer, blind)
+                    r.update(extra)
+                    results.append(r)
+                    ok = "✓" if (r["cam_hit"] and r["answer_ok"] is not False) else "✗"
+                    print(f"{ok} [{label}] {name}: cam={wants} "
+                          f"({time.time() - t0:.1f}s"
+                          f"{', head ' + str(r['head_ms']) + 'ms' if 'head_ms' in r else ''})")
+            stats = score(results)
+            out["archs"][label] = {"stats": stats, "results": results}
+            print(f"\n{label}: {stats}\n")
+    finally:
+        llama.stop()
+
+    if args.out:
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).write_text(json.dumps(out, indent=2))
+        print(f"Wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/camerabench.py
+++ b/benchmarks/camerabench.py
@@ -90,8 +90,7 @@ EXPECTED: dict[str, tuple[bool, list[str]]] = {
 }
 
 SYSTEM = server.SYSTEM_PROMPT + server.CAPABILITY_NOTE + server.RESEARCH_NOTE
-RESPOND_CAM = server.RESPOND_PROMPT.format(
-    camera=" Mention what you see on their camera if relevant.")
+RESPOND_CAM = server.RESPOND_PROMPT.format(camera=server.CAMERA_CLAUSE)
 RESPOND_PLAIN = server.RESPOND_PROMPT.format(camera="")
 
 # The production head prompt + schema, extended with one field: does this
@@ -143,10 +142,12 @@ def prime(messages: list) -> int:
     return round((time.time() - t0) * 1000)
 
 
-def run_head(prefix: list) -> tuple[dict, int]:
+def run_head(messages: list) -> tuple[dict, int]:
+    """One grammar-forced head call over an already-built message list —
+    B rides the prompt on the audio message, C appends its own turn."""
     t0 = time.time()
-    raw, _ = chat(prefix + [{"role": "user", "content": HEAD_PROMPT}],
-                  max_tokens=64, temperature=0.0, json_schema=HEAD_SCHEMA)
+    raw, _ = chat(messages, max_tokens=64, temperature=0.0,
+                  json_schema=HEAD_SCHEMA)
     ms = round((time.time() - t0) * 1000)
     try:
         return json.loads(raw), ms
@@ -180,15 +181,9 @@ def run_arch_b(wav: str, img: str) -> tuple[bool, str, None, dict]:
     prime_ms = prime(base + [{"role": "user", "content": [audio_part(wav)]}])
     # decide_before shape: head prompt rides the same user message as the
     # audio, extending the primed prefix.
-    t0 = time.time()
-    raw, _ = chat(base + [{"role": "user",
-                           "content": [audio_part(wav), text_part(HEAD_PROMPT)]}],
-                  max_tokens=64, temperature=0.0, json_schema=HEAD_SCHEMA)
-    head_ms = round((time.time() - t0) * 1000)
-    try:
-        wants = bool(json.loads(raw).get("camera"))
-    except ValueError:
-        wants = False
+    head, head_ms = run_head(base + [
+        {"role": "user", "content": [audio_part(wav), text_part(HEAD_PROMPT)]}])
+    wants = bool(head.get("camera"))
     content = ([image_part(img), audio_part(wav), text_part(RESPOND_CAM)]
                if wants else [audio_part(wav), text_part(RESPOND_PLAIN)])
     t0 = time.time()
@@ -207,7 +202,7 @@ def run_arch_c(wav: str, img: str) -> tuple[bool, str, str | None, dict]:
     reply, pt = chat(speech)
     turn_ms = round((time.time() - t0) * 1000)
     prefix = speech + [{"role": "assistant", "content": reply}]
-    head, head_ms = run_head(prefix)
+    head, head_ms = run_head(prefix + [{"role": "user", "content": HEAD_PROMPT}])
     wants = bool(head.get("camera"))
     extra = {"turn_ms": turn_ms, "head_ms": head_ms, "prime_ms": prime_ms,
              "prompt_tokens": pt, "raw": reply}
@@ -275,9 +270,8 @@ def score(results: list[dict]) -> dict:
             out[f"{key}_p50"] = vals[len(vals) // 2]
     # What the user waits on a VISION turn, per arch: A = turn (frame was
     # primed); B = head + turn; C = turn1 + head + turn2.
-    vis = [r for r in results if r["needs_camera"]]
     waits = [r.get("head_ms", 0) + r.get("turn_ms", 0) + r.get("turn2_ms", 0)
-             for r in vis]
+             for r in pos]
     if waits:
         waits.sort()
         out["vision_wait_ms_p50"] = waits[len(waits) // 2]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ config is read once at import.
 
 | Variable      | Default                        | Description |
 | ------------- | ------------------------------ | ----------- |
-| `MODEL`       | `e4b`                          | Gemma 4 size: `e2b` (fastest), `e4b` (better answers, ~1.8x e2b latency), `12b` (needs ~8GB) |
+| `MODEL`       | `e4b`                          | Gemma 4 size: `e2b` (fastest), `e4b` (better answers, ~1.8x e2b latency), `12b` (needs ~8GB and llama.cpp b9512+) |
 | `MODEL_PATH`  | auto-download from HuggingFace | Path to a local Gemma 4 `.gguf` file (overrides `MODEL`) |
 | `MMPROJ_PATH` | auto-download from HuggingFace | Path to the matching `mmproj` `.gguf` (audio + vision encoders) |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,67 @@
+# Configuration
+
+Every setting is an environment variable, set in your shell or in a `.env`
+file at the repo root. `.env` is loaded at startup (a real shell variable
+always wins over `.env`); changes need a server restart, because most
+config is read once at import.
+
+## Model
+
+| Variable      | Default                        | Description |
+| ------------- | ------------------------------ | ----------- |
+| `MODEL`       | `e4b`                          | Gemma 4 size: `e2b` (fastest), `e4b` (better answers, ~1.8x e2b latency), `12b` (needs ~8GB) |
+| `MODEL_PATH`  | auto-download from HuggingFace | Path to a local Gemma 4 `.gguf` file (overrides `MODEL`) |
+| `MMPROJ_PATH` | auto-download from HuggingFace | Path to the matching `mmproj` `.gguf` (audio + vision encoders) |
+
+## Server
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `PORT`   | `8000`  | Web server port (serves on `localhost` only — browsers require a secure context for mic/camera) |
+
+## llama.cpp
+
+| Variable           | Default         | Description |
+| ------------------ | --------------- | ----------- |
+| `TEMPERATURE`      | `0.7`           | Sampling temperature for speech (0 = deterministic; the action decider always runs at 0) |
+| `LLAMA_CTX`        | `16384`         | Context size. The server drops the oldest exchanges shortly before it fills |
+| `LLAMA_PORT`       | `8081`          | Port for the spawned llama-server |
+| `LLAMA_SERVER_URL` | (spawn our own) | Use an already-running llama-server instead of spawning one |
+
+## Background research
+
+Off entirely unless `REASONER_API_KEY` is set — without it Parlor stays
+fully on-device. The default endpoint is OpenRouter; any OpenAI-compatible
+chat-completions endpoint works, including a second local llama-server,
+and api.openai.com is handled specially (its reasoning models require
+`max_completion_tokens`, sent automatically). Note that web search is an
+OpenRouter mechanism (the `:online` model suffix): on other endpoints
+research still runs, but without live web access. When pointing directly
+at a provider, use that provider's model id (e.g. `gpt-5.6-luna`, not
+`openai/gpt-5.6-luna`).
+
+| Variable              | Default                        | Description |
+| --------------------- | ------------------------------ | ----------- |
+| `REASONER_API_KEY`    | (unset — research off)         | API key for the endpoint |
+| `REASONER_BASE_URL`   | `https://openrouter.ai/api/v1` | Any OpenAI-compatible chat endpoint |
+| `REASONER_MODEL`      | `openai/gpt-5.6-luna`          | Model the endpoint should run |
+| `REASONER_WEB_SEARCH` | `1`                            | On OpenRouter, append `:online` for provider-side web search |
+| `REASONER_TIMEOUT`    | `90`                           | Seconds before a background task fails (and is delivered as a spoken apology) |
+
+## Behavior
+
+| Variable          | Default | Description |
+| ----------------- | ------- | ----------- |
+| `TIME_NOTE_MIN_S` | `120`   | Seconds of quiet before the next turn tells the model how long the silence was |
+
+## TTS
+
+| Variable      | Default | Description |
+| ------------- | ------- | ----------- |
+| `KOKORO_ONNX` | (unset) | Set to force the ONNX (CPU) TTS backend on Apple Silicon instead of MLX — a debugging escape hatch |
+
+## Testing
+
+| Variable          | Default            | Description |
+| ----------------- | ------------------ | ----------- |
+| `PARLOR_TEST_URL` | (spawn our own)    | Point the e2e suite at an already-running server, e.g. `ws://localhost:8000/ws` |

--- a/src/parlor/llama.py
+++ b/src/parlor/llama.py
@@ -4,9 +4,11 @@ OpenAI-compatible chat API (blocking, streaming, and cache-priming)."""
 import http.client
 import json
 import os
+import re
 import shutil
 import socket
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -75,20 +77,65 @@ def _connect(timeout: float) -> http.client.HTTPConnection:
     return http.client.HTTPConnection(*host_port(), timeout=timeout)
 
 
+# Gemma 4 needs a recent llama.cpp: builds before b9503 lack its audio
+# support or abort loading the E2B/E4B mmproj (upstream #24084; the 12B
+# mmproj needs b9512). An old install otherwise fails with a confusing
+# crash at model load, so the floor is enforced up front.
+MIN_BUILD = 9503
+
+# Install hints must not assume macOS: brew on darwin, upstream's guide
+# everywhere else.
+_INSTALL_HINT = ("brew install llama.cpp" if sys.platform == "darwin" else
+                 "see https://github.com/ggml-org/llama.cpp/blob/master/docs/install.md")
+_UPGRADE_HINT = ("brew upgrade llama.cpp" if sys.platform == "darwin" else
+                 "see https://github.com/ggml-org/llama.cpp/blob/master/docs/install.md")
+
+
+def server_command() -> list[str]:
+    """The llama.cpp server invocation. Homebrew and the release tarballs
+    install `llama-server`; llama.cpp's first-party installer
+    (llama.app/install.sh) instead ships a unified `llama` binary whose
+    `serve` subcommand is the same server."""
+    binary = shutil.which("llama-server")
+    if binary:
+        return [binary]
+    unified = shutil.which("llama")
+    if unified:
+        return [unified, "serve"]
+    raise RuntimeError(f"llama-server not found — install llama.cpp: {_INSTALL_HINT}")
+
+
+def check_build(cmd: list[str]) -> None:
+    """Refuse to start on a llama.cpp build too old for Gemma 4. The
+    version line looks like 'version: 10150 (dee2a846b)'; a binary that
+    reports nothing parseable (self-built trees print 'version: 0
+    (unknown)') is let through — the guard is for stale installs, not
+    custom builds."""
+    try:
+        out = subprocess.run(cmd + ["--version"], capture_output=True,
+                             text=True, timeout=10)
+        m = re.search(r"version:\s*(\d+)", out.stderr + out.stdout)
+    except (OSError, subprocess.SubprocessError):
+        return
+    if m and 0 < int(m.group(1)) < MIN_BUILD:
+        raise RuntimeError(
+            f"llama.cpp build {m.group(1)} is too old for Gemma 4 audio "
+            f"(needs {MIN_BUILD}+, June 2026) — {_UPGRADE_HINT}")
+
+
 def start() -> None:
     global _proc
     if URL:
         print(f"Using external llama-server at {URL}")
         return
-    binary = shutil.which("llama-server")
-    if not binary:
-        raise RuntimeError("llama-server not found — install with: brew install llama.cpp")
+    cmd = server_command()
+    check_build(cmd)
     model, mmproj = resolve_model_paths()
     print(f"Starting llama-server with {Path(model).name} (ctx={CTX})...")
     # Output goes to DEVNULL — un-silence here when debugging llama itself.
     _proc = subprocess.Popen(
-        [binary, "-m", model, "--mmproj", mmproj, "-ngl", "99",
-         "--port", str(PORT), "-c", str(CTX), "-np", "1"],
+        cmd + ["-m", model, "--mmproj", mmproj, "-ngl", "99",
+               "--port", str(PORT), "-c", str(CTX), "-np", "1"],
         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
     )
     deadline = time.time() + 180

--- a/src/parlor/llama.py
+++ b/src/parlor/llama.py
@@ -108,7 +108,7 @@ def server_command() -> list[str]:
     raise RuntimeError(f"llama-server not found — install llama.cpp: {_hint('install')}")
 
 
-def check_build(cmd: list[str], floor: int = MIN_BUILD) -> None:
+def check_build(cmd: list[str], floor: int) -> None:
     """Refuse to start on a llama.cpp build below the model's floor. The
     version is probed on the root binary (`llama serve --version` may not
     exit). Its line looks like 'version: 10150 (dee2a846b)'; a binary

--- a/src/parlor/llama.py
+++ b/src/parlor/llama.py
@@ -78,17 +78,20 @@ def _connect(timeout: float) -> http.client.HTTPConnection:
 
 
 # Gemma 4 needs a recent llama.cpp: builds before b9503 lack its audio
-# support or abort loading the E2B/E4B mmproj (upstream #24084; the 12B
-# mmproj needs b9512). An old install otherwise fails with a confusing
-# crash at model load, so the floor is enforced up front.
+# support or abort loading the E2B/E4B mmproj (upstream #24084), and the
+# 12B mmproj needs b9512. An old install otherwise fails with a confusing
+# crash at model load, so the floor is enforced up front, per model.
 MIN_BUILD = 9503
+MODEL_MIN_BUILD = {"12b": 9512}
 
-# Install hints must not assume macOS: brew on darwin, upstream's guide
-# everywhere else.
-_INSTALL_HINT = ("brew install llama.cpp" if sys.platform == "darwin" else
-                 "see https://github.com/ggml-org/llama.cpp/blob/master/docs/install.md")
-_UPGRADE_HINT = ("brew upgrade llama.cpp" if sys.platform == "darwin" else
-                 "see https://github.com/ggml-org/llama.cpp/blob/master/docs/install.md")
+INSTALL_GUIDE = "https://github.com/ggml-org/llama.cpp/blob/master/docs/install.md"
+
+
+def _hint(verb: str) -> str:
+    """brew on macOS, upstream's guide everywhere else."""
+    if sys.platform == "darwin":
+        return f"brew {verb} llama.cpp"
+    return "see " + INSTALL_GUIDE
 
 
 def server_command() -> list[str]:
@@ -102,25 +105,30 @@ def server_command() -> list[str]:
     unified = shutil.which("llama")
     if unified:
         return [unified, "serve"]
-    raise RuntimeError(f"llama-server not found — install llama.cpp: {_INSTALL_HINT}")
+    raise RuntimeError(f"llama-server not found — install llama.cpp: {_hint('install')}")
 
 
-def check_build(cmd: list[str]) -> None:
-    """Refuse to start on a llama.cpp build too old for Gemma 4. The
-    version line looks like 'version: 10150 (dee2a846b)'; a binary that
-    reports nothing parseable (self-built trees print 'version: 0
+def check_build(cmd: list[str], floor: int = MIN_BUILD) -> None:
+    """Refuse to start on a llama.cpp build below the model's floor. The
+    version is probed on the root binary (`llama serve --version` may not
+    exit). Its line looks like 'version: 10150 (dee2a846b)'; a binary
+    that reports nothing parseable (self-built trees print 'version: 0
     (unknown)') is let through — the guard is for stale installs, not
     custom builds."""
     try:
-        out = subprocess.run(cmd + ["--version"], capture_output=True,
-                             text=True, timeout=10)
+        out = subprocess.run([cmd[0], "--version"], capture_output=True,
+                             text=True, timeout=5)
         m = re.search(r"version:\s*(\d+)", out.stderr + out.stdout)
     except (OSError, subprocess.SubprocessError):
         return
-    if m and 0 < int(m.group(1)) < MIN_BUILD:
+    if m and 0 < int(m.group(1)) < floor:
+        # The upgrade advice must match how llama.cpp was installed: brew
+        # never put the unified `llama` binary there.
+        hint = ("re-run the llama.app installer (or see " + INSTALL_GUIDE + ")"
+                if len(cmd) > 1 else _hint("upgrade"))
         raise RuntimeError(
             f"llama.cpp build {m.group(1)} is too old for Gemma 4 audio "
-            f"(needs {MIN_BUILD}+, June 2026) — {_UPGRADE_HINT}")
+            f"(needs {floor}+, June 2026) — {hint}")
 
 
 def start() -> None:
@@ -129,7 +137,7 @@ def start() -> None:
         print(f"Using external llama-server at {URL}")
         return
     cmd = server_command()
-    check_build(cmd)
+    check_build(cmd, MODEL_MIN_BUILD.get(MODEL, MIN_BUILD))
     model, mmproj = resolve_model_paths()
     print(f"Starting llama-server with {Path(model).name} (ctx={CTX})...")
     # Output goes to DEVNULL — un-silence here when debugging llama itself.

--- a/src/parlor/reasoner.py
+++ b/src/parlor/reasoner.py
@@ -17,7 +17,7 @@ import urllib.request
 BASE_URL = os.environ.get("REASONER_BASE_URL",
                           "https://openrouter.ai/api/v1").rstrip("/")
 API_KEY = os.environ.get("REASONER_API_KEY", "")
-MODEL = os.environ.get("REASONER_MODEL", "anthropic/claude-sonnet-4.5")
+MODEL = os.environ.get("REASONER_MODEL", "openai/gpt-5.6-luna")
 try:
     TIMEOUT_S = float(os.environ.get("REASONER_TIMEOUT", "90"))
 except ValueError:
@@ -49,13 +49,20 @@ def ask(task: str) -> str:
     """Blocking chat-completion call — run it in an executor. Raises on
     transport/HTTP errors and empty answers; the caller turns any failure
     into a spoken apology."""
+    # api.openai.com rejects max_tokens for its reasoning models (GPT-5.x,
+    # o-series) and wants max_completion_tokens — which also covers hidden
+    # reasoning tokens, hence the larger cap there. Every other
+    # OpenAI-compatible endpoint (OpenRouter, llama-server, vLLM) takes
+    # max_tokens. Either way the answer is spoken aloud — cap essays.
+    cap = ({"max_completion_tokens": 4096} if "api.openai.com" in BASE_URL
+           else {"max_tokens": 1024})
     req = urllib.request.Request(
         BASE_URL + "/chat/completions",
         data=json.dumps({
             "model": MODEL,
             "messages": [{"role": "system", "content": SYSTEM_PROMPT},
                          {"role": "user", "content": task}],
-            "max_tokens": 1024,  # the answer is spoken aloud — cap essays
+            **cap,
         }).encode(),
         headers={"Content-Type": "application/json",
                  "Authorization": f"Bearer {API_KEY}"},

--- a/src/parlor/reasoner.py
+++ b/src/parlor/reasoner.py
@@ -49,20 +49,22 @@ def ask(task: str) -> str:
     """Blocking chat-completion call — run it in an executor. Raises on
     transport/HTTP errors and empty answers; the caller turns any failure
     into a spoken apology."""
-    # api.openai.com rejects max_tokens for its reasoning models (GPT-5.x,
-    # o-series) and wants max_completion_tokens — which also covers hidden
-    # reasoning tokens, hence the larger cap there. Every other
-    # OpenAI-compatible endpoint (OpenRouter, llama-server, vLLM) takes
-    # max_tokens. Either way the answer is spoken aloud — cap essays.
-    cap = ({"max_completion_tokens": 4096} if "api.openai.com" in BASE_URL
-           else {"max_tokens": 1024})
+    # api.openai.com rejects max_tokens for its reasoning models and wants
+    # max_completion_tokens; every other OpenAI-compatible endpoint
+    # (OpenRouter, llama-server, vLLM) takes max_tokens. Only the field
+    # name varies: reasoning models spend hidden thinking tokens from the
+    # same budget wherever they run, and the answer stays short because
+    # the system prompt asks for a few spoken sentences — the cap just
+    # stops essays.
+    field = ("max_completion_tokens" if "api.openai.com" in BASE_URL
+             else "max_tokens")
     req = urllib.request.Request(
         BASE_URL + "/chat/completions",
         data=json.dumps({
             "model": MODEL,
             "messages": [{"role": "system", "content": SYSTEM_PROMPT},
                          {"role": "user", "content": task}],
-            **cap,
+            field: 4096,
         }).encode(),
         headers={"Content-Type": "application/json",
                  "Authorization": f"Bearer {API_KEY}"},

--- a/src/parlor/server.py
+++ b/src/parlor/server.py
@@ -203,6 +203,10 @@ RESPOND_PROMPT = (
     "to them: 1-4 short sentences, spoken aloud.{camera}"
 )
 
+# The clause a camera turn appends to its instruction — a named constant
+# so benchmarks measure the production wording, never a retyped copy.
+CAMERA_CLAUSE = " Mention what you see on their camera if relevant."
+
 # Spoken when a turn yields no reply at all (models of every size
 # occasionally emit only the transcript line) — silence would leave the
 # user hanging, and a stored transcript-only reply teaches the model to
@@ -317,7 +321,7 @@ async def root():
 
 def turn_instruction(msg: dict, has_image: bool, has_audio: bool) -> str:
     if has_audio:
-        camera = " Mention what you see on their camera if relevant." if has_image else ""
+        camera = CAMERA_CLAUSE if has_image else ""
         prompt = FLUSH_PROMPT if msg.get("type") == "flush" else RESPOND_PROMPT
         return prompt.format(camera=camera)
     if has_image:

--- a/tests/test_llama_startup.py
+++ b/tests/test_llama_startup.py
@@ -1,0 +1,72 @@
+"""Unit tests for llama-server discovery and the Gemma 4 build floor —
+stub binaries on PATH, no real llama.cpp involved."""
+
+import stat
+
+import pytest
+
+from parlor import llama
+
+
+def _stub(dir, name: str, script: str) -> None:
+    path = dir / name
+    path.write_text(f"#!/bin/sh\n{script}\n")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+@pytest.fixture
+def on_path(tmp_path, monkeypatch):
+    """A bin dir that is the ONLY place binaries resolve from."""
+    monkeypatch.setenv("PATH", str(tmp_path))
+    return tmp_path
+
+
+def test_prefers_llama_server(on_path):
+    _stub(on_path, "llama-server", "")
+    _stub(on_path, "llama", "")
+    assert llama.server_command() == [str(on_path / "llama-server")]
+
+
+def test_falls_back_to_unified_binary(on_path):
+    # llama.cpp's first-party installer ships `llama` with a `serve`
+    # subcommand and no `llama-server` at all.
+    _stub(on_path, "llama", "")
+    assert llama.server_command() == [str(on_path / "llama"), "serve"]
+
+
+def test_missing_binary_says_how_to_install(on_path):
+    with pytest.raises(RuntimeError, match="install llama.cpp"):
+        llama.server_command()
+
+
+def test_old_build_is_refused_with_upgrade_hint(on_path):
+    _stub(on_path, "llama-server", 'echo "version: 9000 (deadbee)" >&2')
+    with pytest.raises(RuntimeError, match="9000 is too old"):
+        llama.check_build(llama.server_command(), 9503)
+
+
+def test_floor_is_per_model(on_path):
+    # b9505 carries e2b/e4b (floor 9503) but not the 12b mmproj (9512).
+    _stub(on_path, "llama-server", 'echo "version: 9505 (deadbee)" >&2')
+    cmd = llama.server_command()
+    llama.check_build(cmd, llama.MIN_BUILD)
+    with pytest.raises(RuntimeError, match="needs 9512"):
+        llama.check_build(cmd, llama.MODEL_MIN_BUILD["12b"])
+
+
+def test_version_probed_on_root_binary(on_path):
+    # `llama serve --version` may not exit — the probe must ask the root
+    # binary, and the failure hint must not say brew (wrong installer).
+    _stub(on_path, "llama",
+          '[ "$1" = "--version" ] && echo "version: 9000 (cafe)" >&2')
+    with pytest.raises(RuntimeError, match="llama.app installer"):
+        llama.check_build(llama.server_command(), llama.MIN_BUILD)
+
+
+def test_unparseable_version_fails_open(on_path):
+    # Self-built trees print 'version: 0 (unknown)' — the guard is for
+    # stale installs, not custom builds.
+    _stub(on_path, "llama-server", 'echo "version: 0 (unknown)" >&2')
+    llama.check_build(llama.server_command(), llama.MIN_BUILD)
+    _stub(on_path, "llama-server", "echo not a version line")
+    llama.check_build(llama.server_command(), llama.MIN_BUILD)


### PR DESCRIPTION
## What's here

- **Reasoner**: default model is now `openai/gpt-5.6-luna`; pointing `REASONER_BASE_URL` directly at api.openai.com works with its reasoning models — that host gets `max_completion_tokens`, everyone else keeps `max_tokens`. The token budget is also raised 1024 → 4096 on all endpoints: the new default is a reasoning model whose hidden thinking spends from the same budget, so 1024 could starve the actual answer (answer length is still governed by the prompt and the server-side clamp).
- **llama.cpp startup**: the first-party installer ships a unified `llama` binary (`llama serve`) that `shutil.which("llama-server")` misses — both are discovered now. Builds below the Gemma 4 floor (b9503; b9512 for `MODEL=12b`) are refused up front with hints matched to how llama.cpp was installed (brew vs the llama.app installer vs the upstream guide), instead of a confusing crash at model load. The version is probed on the root binary, fail-open for self-built trees reporting `version: 0`.
- **Docs**: README reworked — current architecture diagram, one bullet per feature, AI disclosure — and the config table trimmed to the five common variables, with the full grouped inventory (including previously undocumented `KOKORO_ONNX` / `PARLOR_TEST_URL` and `.env` semantics) in `docs/configuration.md`.
- **Camera experiment** (`benchmarks/camerabench.py`): measured attach-every-turn vs camera-as-tool-call. Attaching wins decisively — a frame costs only 50 context tokens and ~600ms of prime GPU hidden under speech; deciding before speech adds ~2.2s to every turn, and deciding after is structurally broken (the blind reply hallucinates, then reads as evidence no frame was needed — recall 0.0). No production change; the findings live in the benchmark docstring.

A `/simplify` + `/code-review` pass ran over this branch: per-model build floor (the flat constant let 12b users through to the exact crash the guard prevents), install-method-aware hints, one shared head call in the bench, and the review's catches folded in.

## Testing

- `tests/test_llama_startup.py` (new): stubbed-binary unit tests for discovery order, the unified fallback, the per-model floor, the root-binary probe, install-method hints, and fail-open on unparseable versions.
- Full e2e suite green on this branch: 78 passed, 1 skipped.

## Follow-ups surfaced by review (not in this PR)

- `pipeline.py`'s `IMAGE_TOKENS = 300` estimate is 6x the measured 50 — conservative (rotates early), worth aligning.
- Third vendored llama-chat helper across benchmarks; a shared bench util would stop the drift.
- `tests/test_z_failure.py` pgreps the literal `llama-server`, which the unified-binary path wouldn't match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)