### PR TITLE
Declare huggingface-hub as a direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "On-device, real-time multimodal AI — have natural voice + visio
 requires-python = ">=3.12,<3.13"
 dependencies = [
     "fastapi>=0.135.3",
+    "huggingface-hub>=1.0.0",
     "kokoro-onnx>=0.5.0; sys_platform == 'linux'",
     "misaki[en]>=0.9.4; sys_platform == 'darwin'",
     "mlx-audio>=0.4.2; sys_platform == 'darwin'",

--- a/uv.lock
+++ b/uv.lock
@@ -335,6 +335,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/53/92/ec9ad04d0b5728dca
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/9f/9c23e4a447b8f83120798f9279d0297a4d1360bdbf59ef49ebec78fe2545/hf_xet-1.4.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d0da85329eaf196e03e90b84c2d0aca53bd4573d097a75f99609e80775f98025", size = 3805048, upload-time = "2026-03-31T22:39:53.105Z" },
     { url = "https://files.pythonhosted.org/packages/0b/f8/7aacb8e5f4a7899d39c787b5984e912e6c18b11be136ef13947d7a66d265/hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583", size = 3562178, upload-time = "2026-03-31T22:39:51.295Z" },
+    { url = "https://files.pythonhosted.org/packages/df/9a/a24b26dc8a65f0ecc0fe5be981a19e61e7ca963b85e062c083f3a9100529/hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08", size = 4212320, upload-time = "2026-03-31T22:39:42.922Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/46d493db155d2ee2801b71fb1b0fd67696359047fdd8caee2c914cc50c79/hf_xet-1.4.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39f2d2e9654cd9b4319885733993807aab6de9dfbd34c42f0b78338d6617421f", size = 3991546, upload-time = "2026-03-31T22:39:41.335Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f5/067363e1c96c6b17256910830d1b54099d06287e10f4ec6ec4e7e08371fc/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:49ad8a8cead2b56051aa84d7fce3e1335efe68df3cf6c058f22a65513885baac", size = 4193200, upload-time = "2026-03-31T22:40:01.936Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
 ]
 
 [[package]]
@@ -786,10 +792,11 @@ wheels = [
 
 [[package]]
 name = "parlor"
-version = "0.1.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "huggingface-hub" },
     { name = "kokoro-onnx", marker = "sys_platform == 'linux'" },
     { name = "misaki", extra = ["en"], marker = "sys_platform == 'darwin'" },
     { name = "mlx-audio", marker = "sys_platform == 'darwin'" },
@@ -811,6 +818,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.135.3" },
+    { name = "huggingface-hub", specifier = ">=1.0.0" },
     { name = "kokoro-onnx", marker = "sys_platform == 'linux'", specifier = ">=0.5.0" },
     { name = "misaki", extras = ["en"], marker = "sys_platform == 'darwin'", specifier = ">=0.9.4" },
     { name = "mlx-audio", marker = "sys_platform == 'darwin'", specifier = ">=0.4.2" },


### PR DESCRIPTION
## Summary
Fixes the reported Linux startup crash (`ModuleNotFoundError: No module named 'huggingface_hub'`).

`parlor` imports `huggingface_hub.hf_hub_download` on every platform — `src/parlor/llama.py`, `src/parlor/tts.py`, and `src/parlor/turn_detector.py` — but the package was never declared, only pulled in transitively via the darwin-only `mlx-audio`. Nothing in the Linux (`kokoro-onnx`) chain provides it, so Linux installs crashed on startup while macOS worked by accident.

## Changes
- `pyproject.toml`: add `huggingface-hub>=1.0.0`, unmarked (needed on all platforms). Floor-only specifier matches the rest of the list and is identical to mlx-audio's own floor, so no resolution conflict; the only API used is `hf_hub_download`, stable across 1.x. `uv.lock` pins the exact version (1.9.0), unchanged from before.
- `uv.lock` re-sync side effects: Linux/Windows `hf_xet` wheels appear (the dep is now reachable outside macOS), and the lock's stale `parlor 0.1.0 → 2.0.0` entry catches up — pre-existing drift from the v2.0.0 release commit that never re-locked, repaired incidentally here.

## Verification
- `uv sync` resolves cleanly; `uv lock --check` passes.
- Import smoke test: `from huggingface_hub import hf_hub_download` succeeds (1.9.0).
- Reviewed by /code-review (0 findings, both platforms verified) and /simplify (nothing to change).

## Follow-up (separate issue)
Both bugs this fixes would have been caught in CI by `uv lock --check` plus a Linux `uv sync` + import smoke test. Worth adding, since development happens on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)